### PR TITLE
[Doppins] Upgrade dependency semantic-ui-react to ^0.81.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "react-relay": "^1.4.1",
     "react-relay-network-modern": "^2.1.1",
     "relay-runtime": "^1.5.0",
-    "semantic-ui-react": "^0.81.0",
+    "semantic-ui-react": "^0.81.1",
     "unstated": "^2.1.1",
     "url-loader": "^1.0.1"
   },


### PR DESCRIPTION
Hi!

A new version was just released of `semantic-ui-react`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded semantic-ui-react from `^0.80.2` to `^0.81.0`

