### PR TITLE
[Doppins] Upgrade dependency graphql-cli to 2.16.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-react": "^7.7.0",
     "eslint-plugin-relay": "^0.0.21",
     "flow-bin": "0.73.0",
-    "graphql-cli": "2.16.1",
+    "graphql-cli": "2.16.2",
     "prettier": "^1.11.1",
     "relay-compiler": "^1.4.1",
     "semantic-ui-css": "^2.3.1"


### PR DESCRIPTION
Hi!

A new version was just released of `graphql-cli`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded graphql-cli from `2.16.1` to `2.16.2`

#### Changelog:

#### Version 2.16.2
## 2.16.2 (`https://github.com/graphql-cli/graphql-cli/compare/v2.16.1...v2.16.2`) (2018-06-07)


### Bug Fixes

* **boilerplates:** add ts-minimal (44ba44c (`https://github.com/graphql-cli/graphql-cli/commit/44ba44c`))





