### PR TITLE
[Doppins] Upgrade dependency graphql-cli to 2.16.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-react": "^7.7.0",
     "eslint-plugin-relay": "^0.0.21",
     "flow-bin": "0.74.0",
-    "graphql-cli": "2.16.2",
+    "graphql-cli": "2.16.3",
     "prettier": "^1.11.1",
     "relay-compiler": "^1.4.1",
     "semantic-ui-css": "^2.3.1"


### PR DESCRIPTION
Hi!

A new version was just released of `graphql-cli`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded graphql-cli from `2.16.2` to `2.16.3`

#### Changelog:

#### Version 2.16.3
## 2.16.3 (`https://github.com/graphql-cli/graphql-cli/compare/v2.16.2...v2.16.3`) (2018-06-12)


### Bug Fixes

* get-schema experience (`#320`](`https://github.com/graphql-cli/graphql-cli/issues/320`)) ([4f312df (`https://github.com/graphql-cli/graphql-cli/commit/4f312df`))





