### PR TITLE
[Doppins] Upgrade dependency eslint to ^5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "babel-eslint": "^8.2.2",
     "babel-plugin-relay": "^1.4.1",
-    "eslint": "^4.19.1",
+    "eslint": "^5.0.0",
     "eslint-config-prettier": "^2.9.0",
     "eslint-config-react-app": "^2.1.0",
     "eslint-plugin-flowtype": "^2.46.1",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint from `^4.19.1` to `^5.0.0`

#### Changelog:

#### Version 5.0.0
* abf400d Update: Add ignoreDestructing option to camelcase rule (fixes `#9807`) (`#10373`) (Andrew Lunny)
* e2b394d Upgrade: espree and eslint-scope to rc versions (`#10457`) (Kevin Partington)
* a370da2 Chore: small opt to improve readability (`#10241`) (薛定谔的猫)
* 640bf07 Update: Fixes multiline no-warning-comments rule. (fixes `#9884`) (`#10381`) (Scott Stern)
* 831c39a Build: Adding rc release script to package.json (`#10456`) (Kevin Partington)
* dc4075e Update: fix false negative in no-use-before-define (fixes `#10227`) (`#10396`) (Toru Nagashima)
* 3721841 Docs: Add new experimental syntax policy to README (fixes `#9804`) (`#10408`) (Kevin Partington)
* d0aae3c Docs: Create docs landing page (`#10453`) (Kevin Partington)
* fe8bec3 Fix: fix writing config file when `source` is `prompt` (`#10422`) (Pig Fang)
* 917108d Update: Add requireParamType option to valid-jsdoc (fixes `#6753`) (`#10220`) (Tomasz Sterna)
* 1984c21 Docs: move custom parsers docs into a page (fixes `#9919`) (`#10431`) (Pig Fang)
* 400d4b5 Docs: Add rest and spread operator changes to migration guide (`#10416`) (Yannick Croissant)
* e7bdd02 Upgrade: Consume espree@4.0.0-alpha.1 (`#10410`) (Kevin Partington)
* 3e9f33a Fix: prevent crashing from JSON parsing error (fixes `#10364`) (`#10376`) (Pig Fang)
* 636457d Fix: parse later ES files in `eslint --init` (fixes `#10003`) (`#10378`) (Pig Fang)

#### Version 5.0.0
* ce3e62a Docs: remove test coverage badge (`#10407`) (薛定谔的猫)
* 240c1a4 Fix: prefer-const object destructuring false positive (fixes `#9108`) (`#10368`) (Pig Fang)
* 93c9a52 Update: config-validator should validate overrides (`#10357`) (Toru Nagashima)
* c2e0398 Update: Improves the prefer-object-spread rule by removing extraneous visitors (`#10351`) (Sharmila Jesupaul)
* d848949 Update: Support JSXFragment node (fixes `#9662`) (`#9664`) (Clement Hoang)
* f268128 Build: add Node v10 to travis (`#10262`) (alberto)
* 9c922ce Update: Add "consistent" option to array-element-newline (fixes `#9457`) (`#10355`) (Pig Fang)
* 65bce3a Fix: ensure --stdin flag works when stdin is piped asynchronously (`#10393`) (Teddy Katz)
* b9b23a9 Chore: rm unused argument (`#10400`) (薛定谔的猫)
* 8b7a70c Fix: handle one-var with no semicolon (fixes `#10330`) (`#10371`) (Malcolm Groves)
* 465e615 New: prompt users before installing dependencies (`#10353`) (Pig Fang)
* e25fc22 Chore: remove assert.doesNotThrow in tests (`#10199`) (Ruben Bridgewater)
* fb148aa Fix: allow no tokens after `return` keyword (fixes `#10372`) (`#10379`) (Pig Fang)
* 074bc1c Docs: polish for max-classes-per-file rule (`#10377`) (Pig Fang)
* a812845 Fix: allow array spread for prefer-object-spread rule (fixes `#10344`) (`#10347`) (Pig Fang)
* 448fc52 Docs: Update link to Integrations / Build tools / Start (`#10354`) (Kir Belevich)
* 4e5e9be Chore: avoid unnecessary filesystem accesses during config search (`#10359`) (Teddy Katz)
* 363da01 Chore: avoid code duplication in rule severity checking (`#10358`) (Teddy Katz)

#### Version 5.0.0
* 1a6b399 New: Adds prefer-object-spread rule (refs: `#7230`) (`#9955`) (Sharmila Jesupaul)
* c4109b2 New: add max-classes-per-file rule (`#10163`) (James Garbutt)
* 41f0f6e Breaking: report multiline eslint-disable-line directives (fixes `#10334`) (`#10335`) (Teddy Katz)
* 4ccd25a Chore: add eslint-plugin-node to eslint-config-eslint(fixes `#10319`) (`#10320`) (薛定谔的猫)
* 82757b2 Docs: Adding a little guidance to rule documentation (`#10301`) (Justin)
* 09dde26 Breaking: new object-curly-newline/no-self-assign default (fixes `#10215`) (`#10337`) (Teddy Katz)
* d65f11d Fix: correct comma fix in spare array (fixes `#10273`) (`#10329`) (Malcolm Groves)
* c343d86 Fix: do not autofix octal escape sequence (fixes `#10031`) (`#10240`) (Malcolm Groves)
* 514013c New: Add `globInputPaths` CLIEngine option (fixes `#9972`) (`#10191`) (Pierre Vanduynslager)
* 02e7b28 Chore: upgrade deps (`#10339`) (薛定谔的猫)
* 1397179 Chore: unskip test for scope analysis (`#10336`) (Teddy Katz)
* e5b33be Update: Add --fix for one-var rule (refs `#9072`) (`#10040`) (Sebastian Malton)
* 99b842d Chore: upgrade mock-fs@4.5.0 (`#10325`) (Tim Schaub)
* fe91859 Chore: Update issue templates with new format (`#10309`) (Ilya Volodin)
* 2f30aa5 Docs: add a better vim linting engine (`#10292`) (Jon Smithers)
* df2c1fb Docs: improve formatter guide (refs `#9550`) (`#10294`) (Dominic Lee)
* f7330c1 Chore: Add ESLint path to plugin-missing message (`#10283`) (Kevin Partington)
* bb6090f Fix: Throw error when --ignore-path not a file (fixes `#10076`) (`#10205`) (Malcolm Groves)
* 1b6b2b2 Build: remove trailing spaces in blogpost template (`#10280`) (Teddy Katz)
* a960d69 Docs: remove outdated notes from migration guide (`#10279`) (Teddy Katz)

#### Version 5.0.0
* 510ca8b Docs: make grammatical tweaks in migration guide (`#10278`) (Teddy Katz)
* 02e44a5 Breaking: remove TDZ scopes (fixes `#10245`) (`#10270`) (Toru Nagashima)
* c74933b Breaking: remove extra check in getScope (fixes `#10246`, fixes `#10247`) (`#10252`) (Toru Nagashima)
* 7c2e83a Chore: improve tests and checking for equality (`#10182`) (Ruben Bridgewater)
* 8799972 Docs: make template link wording more clear (`#10219`) (David Luzar)
* 8b7c6ea Breaking: report fatal error for linting nonexistent files (fixes `#7390`) (`#10143`) (Teddy Katz)
* 9100819 Breaking: fix plugin resolver in extends (fixes `#9904`) (`#10236`) (Toru Nagashima)
* c45f1d0 Breaking: add rules to recommended (fixes `#8865`) (`#10158`) (薛定谔的猫)
* 1d443a0 Fix: valid-jsdoc does not know async function returns (fixes `#9881`) (`#10161`) (Rachael Sim)
* a82cbea Update: re-enable experimentalObjectRestSpread (fixes `#9990`) (`#10230`) (Toru Nagashima)
* f9c7371 Fix: do not autofix object-shorthand with comments (fixes `#10038`) (`#10238`) (Malcolm Groves)
* 4672b56 Docs: Correct wording in the `smart-tabs` docs page (`#10277`) (Jed Fox)
* b32d1f4 Chore: upgrade eslump@1.6.2 (`#10258`) (薛定谔的猫)
* 7938bf1 Chore: update eslint-fuzzer ecmaVersion to 2018 (`#10255`) (薛定谔的猫)
* a2953ec Chore: small opt to improve readability (`#10225`) (薛定谔的猫)
* 85a5191 Docs: Update JSCS FAQ (`#10221`) (alberto)
* 8e89d5c Docs: Fix typo (`#10223`) (alberto)
* c0c331e Docs: Add Prettier to FAQ (`#10222`) (alberto)
* 2443627 Docs: add backticks in getter-return (`#10218`) (薛定谔的猫)
* 74bb5b5 Docs: Fix misspelling in changelog (`#10216`) (Kevin Partington)

#### Version 5.0.0
* b2a48a9 Breaking: stop using fake `context._linter` property (fixes `#10140`) (`#10209`) (Teddy Katz)
* a039956 Breaking: remove deprecated browser/jest/node globals (fixes `#10141`) (`#10210`) (Teddy Katz)
* 98f1cad Docs: update migration guide with latest changes (`#10212`) (Teddy Katz)
* 2e60017 Chore: remove concat-stream dependency (`#10173`) (Teddy Katz)
* 7f69f11 Chore:  rearrange init options. (`#10131`) (薛定谔的猫)
* f595fd8 Upgrade: upgrade deps (`#10184`) (alberto)
* 71167be Docs: fix wrong config in id-length (`#10196`) (薛定谔的猫)
* 81629d2 Chore: enable rest/spread rules on ESLint codebase (`#10211`) (Teddy Katz)
* 2324570 Breaking: no-unused-vars reports all after-used params (fixes `#9909`) (`#10119`) (Kevin Partington)
* 7765fc4 Upgrade: ajv@^6.0.1, still using json schema draft 04 (`#9856`) (Kevin Partington)
* b77846d Breaking: drop supporting Node.js 4 (fixes `#10052`) (`#10074`) (薛定谔的猫)
* cd34d44 Chore: avoid modifying global state when tests fail (`#10201`) (Teddy Katz)
* 731da1e Docs: fix code in correct example. (`#10195`) (薛定谔的猫)
* 3780915 Docs: fix some small errors in examples (`#10194`) (薛定谔的猫)
* 869c9f5 Upgrade: babelify (`#10185`) (alberto)
* 218ee57 Fix: report no-case-declarations from declarations (fixes `#10048`) (`#10167`) (Carlo Abelli)
* b7ee1ed Upgrade: upgrade devdeps (`#10178`) (alberto)
* db1a582 Chore: Add debug logging for CLI args as they came in (`#10174`) (Kevin Partington)
* f3a0291 Upgrade: Update dependencies. (`#10168`) (alberto)
* 7d6e052 Upgrade: esquery@^1.0.1 (fixes `#8733`) (`#10170`) (Kevin Partington)
* 1e7252f Docs: Add more related rules for object-curly-spacing (`#10175`) (Saugat Acharya)
* e5cf9cc Docs: Reorder README sections (`#10172`) (alberto)
* c85578f Chore: Remove `esprima-fb` dependency. (`#10171`) (alberto)
* d0dc2e3 Docs: Add Missing Quotes (`#10162`) (Samarth Verma)
* 7a63bfa Upgrade: eslint-release to v0.11.1 (`#10156`) (Teddy Katz)
* b7a1a7a Build: Gensite creates prerelease dirs if needed (`#10154`) (Brandon Mills)

#### Version 5.0.0
* f4b3af5 Breaking: Upgrade to Espree v4 alpha (refs `#9990`) (`#10152`) (Brandon Mills)
* 3351129 Docs: add v5.0.0 migration guide (fixes `#10142`) (`#10147`) (Teddy Katz)
* f2f98dd Build: make prerelease script publish to GitHub/website (`#10151`) (Teddy Katz)
* d440e84 Breaking: support `@scope` shorthand in plugins (fixes `#9903`) (`#9905`) (Toru Nagashima)
* 462b058 Update: Include debugging information when rule throws error (`#9742`) (Patrick Hayes)
* 9a020dc Chore: refactor --no-ignore flag logic (`#10146`) (Teddy Katz)
* 4f61a0d Chore: add noopener/noreferrer (薛定谔的猫)
* 65cc834 Docs: Ensure CLI doc sections match command line help order (`#10144`) (Kevin Partington)
* 9c79174 Docs: Update capitalized-comments with missing letters (fixes `#10135`) (`#10134`) (jasonfry)
* 9e66bfb Docs: remove eslint vs jshint from faq (`#10108`) (alberto)
* 692e383 Docs: Add modified variable examples for no-loop-func (fixes `#9527`) (`#10098`) (Rachael Sim)
* a9ee9ae Breaking: require rules to provide report messages (fixes `#10011`) (`#10057`) (Teddy Katz)
* 837edc7 Chore: Uncommented test for empty program for no-invalid-meta (`#10046`) (Kevin Partington)
* c383bc5 Breaking: Make require('eslint').linter non-enumerable (fixes `#9270`) (`#9692`) (Jed Fox)
* 4eaebe5 Breaking: set `parent` of AST nodes before rules run (fixes `#9122`) (`#10014`) (Teddy Katz)
* 91ece32 Breaking: remove special exception for linting empty files (fixes `#9534`) (`#10013`) (Teddy Katz)
* 27e3f24 Breaking: remove `source` property from linting messages (fixes `#7358`) (`#10012`) (Teddy Katz)
* e4c3b3c Breaking: use an exit code of 2 for fatal config problems (fixes `#9384`) (`#10009`) (Teddy Katz)
* 2a7ecaa Breaking: Use strict equality in RuleTester comparisons (fixes `#9417`) (`#10008`) (Teddy Katz)
* 0bc4a38 Fix: Make rule-tester strictly check messageId. (ref `#9890`) (`#9908`) (Jacques Favreau)
* ea6fb17 Update: Make no-cond-assign work for ternaries (fixes `#10091`) (`#10109`) (Aaron Harper)

