### PR TITLE
[Doppins] Upgrade dependency graphql-cli to 2.16.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "eslint-plugin-react": "^7.7.0",
     "eslint-plugin-relay": "^0.0.23",
     "flow-bin": "0.75.0",
-    "graphql-cli": "2.16.3",
+    "graphql-cli": "2.16.4",
     "jest": "^23.2.0",
     "jest-puppeteer": "^3.2.1",
     "prettier": "^1.11.1",


### PR DESCRIPTION
Hi!

A new version was just released of `graphql-cli`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded graphql-cli from `2.16.3` to `2.16.4`

#### Changelog:

#### Version 2.16.4
## 2.16.4 (`https://github.com/graphql-cli/graphql-cli/compare/v2.16.3...v2.16.4`) (2018-07-03)


### Bug Fixes

* remove plugin exists warning (`#330`](`https://github.com/graphql-cli/graphql-cli/issues/330`)) ([ee9c0ce (`https://github.com/graphql-cli/graphql-cli/commit/ee9c0ce`))





