### PR TITLE
[Doppins] Upgrade dependency eslint-plugin-relay to ^0.0.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "eslint-plugin-import": "^2.10.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.7.0",
-    "eslint-plugin-relay": "^0.0.23",
+    "eslint-plugin-relay": "^0.0.24",
     "flow-bin": "0.75.0",
     "graphql-cli": "2.16.3",
     "jest": "^23.2.0",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint-plugin-relay`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint-plugin-relay from `^0.0.23` to `^0.0.24`

