### PR TITLE
[Doppins] Upgrade dependency flow-bin to 0.77.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.7.0",
     "eslint-plugin-relay": "^0.0.24",
-    "flow-bin": "0.76.0",
+    "flow-bin": "0.77.0",
     "graphql-cli": "2.16.4",
     "jest": "^23.2.0",
     "jest-puppeteer": "^3.2.1",


### PR DESCRIPTION
Hi!

A new version was just released of `flow-bin`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded flow-bin from `0.76.0` to `0.77.0`

