### PR TITLE
[Doppins] Upgrade dependency recompose to ^0.28.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-relay": "^1.4.1",
     "react-relay-network-modern": "^2.1.1",
     "react-select": "^2.0.0-beta.7",
-    "recompose": "^0.27.1",
+    "recompose": "^0.28.0",
     "relay-runtime": "^1.5.0",
     "styled-components": "^3.3.3",
     "styled-flex-component": "^2.2.2",


### PR DESCRIPTION
Hi!

A new version was just released of `recompose`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded recompose from `^0.27.1` to `^0.28.0`

