### PR TITLE
[Doppins] Upgrade dependency graphql-cli to 2.16.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "eslint-plugin-react": "^7.7.0",
     "eslint-plugin-relay": "^0.0.24",
     "flow-bin": "0.77.0",
-    "graphql-cli": "2.16.4",
+    "graphql-cli": "2.16.5",
     "jest": "^23.2.0",
     "jest-puppeteer": "^3.2.1",
     "prettier": "^1.11.1",


### PR DESCRIPTION
Hi!

A new version was just released of `graphql-cli`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded graphql-cli from `2.16.4` to `2.16.5`

#### Changelog:

#### Version 2.16.5
## 2.16.5 (`https://github.com/graphql-cli/graphql-cli/compare/v2.16.4...v2.16.5`) (2018-07-24)


### Bug Fixes

* **get-schema:** if endpoint is provided, ignore all (`#332`](`https://github.com/graphql-cli/graphql-cli/issues/332`)) ([294f498](`https://github.com/graphql-cli/graphql-cli/commit/294f498`)), closes [`#299` (`https://github.com/graphql-cli/graphql-cli/issues/299`)





