### PR TITLE
Replace Raleway with rawline as main font

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -26,10 +26,7 @@ export default class Default extends Document {
             name="viewport"
             content="width=device-width, initial-scale=1, maximum-scale=1"
           />
-          <link
-            href="https://fonts.googleapis.com/css?family=Raleway:400,500,600,700,400italic,700italic&subset=latin"
-            rel="stylesheet"
-          />
+          <link href="https://cdn.rawgit.com/h-ibaldo/Raleway_Fixed_Numerals/master/css/rawline.css" rel="stylesheet" /> 
           <style>{`
             body {
               margin: 0;
@@ -38,7 +35,7 @@ export default class Default extends Document {
               color: rgba(0, 0, 0, 0.87);
               font-smoothing: antialiased;
               word-break: break-word;
-              font-family: Raleway;
+              font-family: rawline;
             }
             img {
               max-width: 100%;

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -26,7 +26,10 @@ export default class Default extends Document {
             name="viewport"
             content="width=device-width, initial-scale=1, maximum-scale=1"
           />
-          <link href="https://cdn.rawgit.com/h-ibaldo/Raleway_Fixed_Numerals/master/css/rawline.css" rel="stylesheet" /> 
+          <link
+            href="https://cdn.rawgit.com/h-ibaldo/Raleway_Fixed_Numerals/master/css/rawline.css"
+            rel="stylesheet"
+          />
           <style>{`
             body {
               margin: 0;


### PR DESCRIPTION
Switch out the normal Raleway font with the off-brand rawline font. It's the exact same font with `Lining figures` as numbers. This makes all numbers appear on the same line.
<img width="678" alt="screenshot 2019-01-05 at 00 44 35" src="https://user-images.githubusercontent.com/23152018/50716732-42dc3a00-1083-11e9-9fb2-2e8a0f8852de.png">
