### PR TITLE
Change flow use max 4 workers so circleCI stops crashing 9/10 times

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -9,3 +9,4 @@ flow-typed/
 
 [options]
 suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
+server.max_workers=4


### PR DESCRIPTION
Ref: https://github.com/flowtype/flow-bin/issues/138#issuecomment-448416874

This hopefully stops circle failing when running flow on 9/10 runs.