### PR TITLE
Fix shallow routing for dynamic routes

### DIFF
--- a/components/CompactProgram/index.js
+++ b/components/CompactProgram/index.js
@@ -70,14 +70,14 @@ const CompactProgram = () => (
         </Link>
       </Tile>
       <Tile color={itdageneLightBlue}>
-        <Link href="/info/stands">
+        <Link href="/info/[side]" as="/info/stands">
           <CenterIt text>
             <StyledLink>Stands</StyledLink>
           </CenterIt>
         </Link>
       </Tile>
       <Tile color={itdageneYellow}>
-        <Link href="/info/bankett">
+        <Link href="/info/[info]" as="/info/bankett">
           <CenterIt text>
             <StyledLink>Bankett</StyledLink>
           </CenterIt>

--- a/components/Companies/Companies.js
+++ b/components/Companies/Companies.js
@@ -38,7 +38,10 @@ const Companies = ({ query }: Props) => {
       </Flex>
       <h4 style={{ textAlign: 'center' }}>
         <Link>
-          <a href="/info/stands"> Kart over stands </a>
+          <a href="/info/[side]" as="/info/stands">
+            {' '}
+            Kart over stands{' '}
+          </a>
         </Link>
       </h4>
     </Fragment>

--- a/components/Header/index.js
+++ b/components/Header/index.js
@@ -42,15 +42,16 @@ const items = [
   {
     key: 'for-bedrifter',
     name: 'FOR BEDRIFTER',
-    to: '/info/for-bedrifter'
+    to: '/info/[side]',
+    as: '/info/for-bedrifter'
   }
 ];
 
 const MenuItem = withRouter(
   ({ item, router }: { item: Object, router: NextRouter }) => {
-    const { to, name } = item;
+    const { to, name, as } = item;
     return (
-      <Link href={to}>
+      <Link href={to} as={as}>
         <a>
           <StyledMenuItem active={item.to === router.asPath}>
             {name}

--- a/components/Joblistings/JoblistingsContainer.js
+++ b/components/Joblistings/JoblistingsContainer.js
@@ -120,7 +120,7 @@ const ListRenderer = props => (
         {props.root &&
           props.root.joblistings.edges.map(({ node }) => (
             <CompanyElement key={node.id}>
-              <Link key={node.id} href={`/jobb/${node.id}`}>
+              <Link key={node.id} href={'/jobb/[id]'} as={`/jobb/${node.id}`}>
                 <a>
                   <CompanyImage
                     src={node.company.logo || '/static/itdagene-gray.png'}

--- a/pages/index.js
+++ b/pages/index.js
@@ -68,7 +68,7 @@ const EventsSection = ({ query }: { query: pages_index_QueryResponse }) => (
             <h2> {element.title} </h2>
             <p>{element.ingress}</p>
             <Centered>
-              <Link href={`/info/${element.slug}`}>
+              <Link href="/info/[side]" as={`/info/${element.slug}`}>
                 <a>
                   <ReadMore>Les mer</ReadMore>
                 </a>

--- a/pages/info.js
+++ b/pages/info.js
@@ -6,18 +6,19 @@ import Router from 'next/router';
 // For client redirects
 const Redirect = props => {
   useEffect(() => {
-    Router.replace(props.newLocation);
-  }, [props.newLocation]);
+    Router.replace(props.newLink, props.newLocation);
+  }, [props.newLink, props.newLocation]);
   return null;
 };
 
 // For SSR redirects
 Redirect.getInitialProps = ({ res, query }) => {
   const newLocation = `/info/${query.side}`;
+  const newLink = `/info/[side]`;
   if (res) {
     res.writeHead(301, { Location: newLocation });
     res.end();
   }
-  return { newLocation };
+  return { newLocation, newLink };
 };
 export default Redirect;

--- a/pages/jobbannonse.js
+++ b/pages/jobbannonse.js
@@ -6,18 +6,19 @@ import Router from 'next/router';
 // For client redirects
 const Redirect = props => {
   useEffect(() => {
-    Router.replace(props.newLocation);
-  }, [props.newLocation]);
+    Router.replace(props.newLink, props.newLocation);
+  }, [props.newLink, props.newLocation]);
   return null;
 };
 
 // For SSR redirects
 Redirect.getInitialProps = ({ res, query }) => {
   const newLocation = `/jobb/${query.id}`;
+  const newLink = '/jobb/[id]';
   if (res) {
     res.writeHead(301, { Location: newLocation });
     res.end();
   }
-  return { newLocation };
+  return { newLocation, newLink };
 };
 export default Redirect;


### PR DESCRIPTION
#184 broke shallow routing to the dynamic routes. (should have tested more :upside_down_face: ) This caused the entire page to be refreshed when navigating to a dynamic route. (f.ex. `/jobb/[id]`).

See https://nextjs.org/docs/api-reference/next/link#dynamic-routes