### PR TITLE
Add dynamic navbar to /info/[side] & change header items

### DIFF
--- a/components/Header/index.js
+++ b/components/Header/index.js
@@ -36,13 +36,13 @@ const StyledMenuItem = styled('span')`
 
 const items = [
   { key: 'home', name: 'HJEM', to: '/' },
-  { key: 'about-us', name: 'INFO', to: '/om-itdagene' },
+  { key: 'about-us', name: 'OM ITDAGENE', to: '/om-itdagene' },
   { key: 'program', name: 'PROGRAM', to: '/program' },
   { key: 'joblistings', name: 'JOBB', to: '/jobb' },
   {
-    key: 'for-bedrifter',
-    name: 'FOR BEDRIFTER',
-    to: '/info/[side]',
+    key: 'info',
+    name: 'INFO',
+    to: '/info/for-bedrifter',
     as: '/info/for-bedrifter'
   }
 ];

--- a/components/Joblistings/JoblistingsContainer.js
+++ b/components/Joblistings/JoblistingsContainer.js
@@ -120,7 +120,7 @@ const ListRenderer = props => (
         {props.root &&
           props.root.joblistings.edges.map(({ node }) => (
             <CompanyElement key={node.id}>
-              <Link key={node.id} href={'/jobb/[id]'} as={`/jobb/${node.id}`}>
+              <Link key={node.id} href={'/jobb/[id]'} as={`/jobb/${node.slug}`}>
                 <a>
                   <CompanyImage
                     src={node.company.logo || '/static/itdagene-gray.png'}
@@ -221,6 +221,7 @@ export const JoblistingsList = createPaginationContainer(
           ) {
           edges {
             node {
+              slug
               id
               __typename
               type

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -50,9 +50,7 @@ const Navbar = ({ items }: Props) => {
   return (
     <div>
       <Flex>
-        {items.map(item => (
-          <NavbarItem key={item.key} item={item} />
-        ))}
+        {items.map(item => item && <NavbarItem key={item.key} item={item} />)}
       </Flex>
       <Hr />
     </div>

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -1,0 +1,51 @@
+//@Flow
+import * as React from 'react';
+import styled from 'styled-components';
+import Link from 'next/link';
+import { withRouter } from 'next/router';
+import Flex, { FlexItem } from 'styled-flex-component';
+
+type Props = {
+  items: {
+    text: String,
+    href: String,
+    as: String
+  }
+};
+
+const StyledNavbarItem = styled('div')`
+  padding-right: 20px;
+  font-weight: bold;
+`;
+
+const NavbarItem = withRouter(({ item, router }) => {
+  const isActive = router.asPath === item.as;
+  return (
+    <FlexItem>
+      {!isActive ? (
+        <Link href={item.href} as={item.as}>
+          <a>
+            <StyledNavbarItem>{item.text}</StyledNavbarItem>
+          </a>
+        </Link>
+      ) : (
+        <StyledNavbarItem>{item.text}</StyledNavbarItem>
+      )}
+    </FlexItem>
+  );
+});
+
+const Navbar = ({ items }: Props) => {
+  return (
+    <div>
+      <Flex>
+        {items.map(item => (
+          <NavbarItem key={item.key} item={item} />
+        ))}
+      </Flex>
+      <hr />
+    </div>
+  );
+};
+
+export default Navbar;

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -18,6 +18,17 @@ const StyledNavbarItem = styled('div')`
   font-weight: bold;
 `;
 
+const Hr = styled('hr')`
+  background-image: linear-gradient(
+    to right,
+    rgba(0, 0, 0, 0.1),
+    rgba(0, 0, 0, 0.7),
+    rgba(0, 0, 0, 0.1)
+  );
+  height: 1px;
+  border: 0;
+`;
+
 const NavbarItem = withRouter(({ item, router }) => {
   const isActive = router.asPath === item.as;
   return (
@@ -43,7 +54,7 @@ const Navbar = ({ items }: Props) => {
           <NavbarItem key={item.key} item={item} />
         ))}
       </Flex>
-      <hr />
+      <Hr />
     </div>
   );
 };

--- a/lib/ServerError.js
+++ b/lib/ServerError.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import Error from 'next/error';
+
+const ServerError = ({ statusCode, title, errorCode }) => {
+  if (process.browser) {
+    return <Error statusCode={statusCode} title={title} />;
+  }
+  const error = new Error();
+  error.code = errorCode;
+  throw error;
+};
+
+export default ServerError;

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -1,0 +1,44 @@
+// @flow
+import React from 'react';
+import Layout from '../components/Layout';
+import { CenterIt } from '../components/Styled';
+import Flex, { FlexItem } from 'styled-flex-component';
+import styled from 'styled-components';
+
+type Props = {
+  statusCode: number,
+  title: string
+};
+
+const ERROR_TITLES = {
+  '404': 'Fant ikke siden :(',
+  '500': 'Noe har gått fryktelig galt.'
+};
+
+const H1 = styled('h1')`
+  font-size: 8em;
+  margin-bottom: 10px;
+  font-weight: 100;
+`;
+
+const Error = ({ statusCode, title }: Props) => {
+  return (
+    <Layout noLoading>
+      <Flex center full>
+        <FlexItem>
+          <CenterIt text>
+            <H1>{statusCode}</H1>
+            <h2>{title || ERROR_TITLES[statusCode] || 'En feil oppsto'}</h2>
+          </CenterIt>
+        </FlexItem>
+      </Flex>
+    </Layout>
+  );
+};
+
+Error.getInitialProps = ({ res, err }) => {
+  const statusCode = res ? res.statusCode : err ? err.statusCode : 404;
+  return { statusCode };
+};
+
+export default Error;

--- a/pages/info/[side].js
+++ b/pages/info/[side].js
@@ -4,6 +4,10 @@ import {
   withDataAndLayout,
   type WithDataAndLayoutProps
 } from '../../lib/withData';
+import Navbar from '../../components/Navbar';
+import { CenterIt } from '../../components/Styled';
+import styled from 'styled-components';
+import Flex, { FlexItem } from 'styled-flex-component';
 
 import { graphql } from 'react-relay';
 import { type Side_info_QueryResponse } from './__generated__/Side_info_Query.graphql';
@@ -12,22 +16,56 @@ import PageView from '../../components/PageView';
 
 type RenderProps = WithDataAndLayoutProps<Side_info_QueryResponse>;
 
-const Index = ({ props }: RenderProps) => (
-  <>
-    {props.page ? (
-      <PageView page={props.page} />
-    ) : (
-      <>
-        <h1>Finner ikke siden :( </h1>
-        <h2>404 Errr</h2>
-      </>
-    )}
-  </>
-);
+const StyledHeading = styled('h1')`
+  font-weight: 200;
+  font-size: 4em;
+  margin: 0;
+`;
+
+const StyledPageView = styled('div')`
+  margin-left: 0;
+`;
+
+const Index = ({ props }: RenderProps) => {
+  const { page, pages } = props;
+  const navitems = pages.map(page => ({
+    text: page.title || '',
+    href: '/info/[side]',
+    as: `/info/${page.slug}`,
+    key: page.id
+  }));
+  return (
+    <>
+      <StyledHeading>INFO</StyledHeading>
+      <Navbar items={navitems} />
+      {page ? (
+        <StyledPageView>
+          <PageView page={page} />
+        </StyledPageView>
+      ) : (
+        <>
+          <Flex center full>
+            <FlexItem>
+              <CenterIt text>
+                <h1>Finner ikke siden :( </h1>
+                <h2>404 Errr</h2>
+              </CenterIt>
+            </FlexItem>
+          </Flex>
+        </>
+      )}
+    </>
+  );
+};
 
 export default withDataAndLayout(Index, {
   query: graphql`
     query Side_info_Query($side: String!) {
+      pages(infopage: true) {
+        title
+        slug
+        id
+      }
       page(slug: $side) {
         ... on Page {
           ...PageView_page
@@ -39,7 +77,6 @@ export default withDataAndLayout(Index, {
   variables: ({ query: { side = '' } }) => ({ side }),
   layout: ({ props, error }) => ({
     responsive: true,
-    shouldCenter: !!props && !props.page,
     metadata: props && props.page
   })
 });

--- a/pages/info/[side].js
+++ b/pages/info/[side].js
@@ -5,9 +5,8 @@ import {
   type WithDataAndLayoutProps
 } from '../../lib/withData';
 import Navbar from '../../components/Navbar';
-import { CenterIt } from '../../components/Styled';
+import ServerError from '../../lib/ServerError';
 import styled from 'styled-components';
-import Flex, { FlexItem } from 'styled-flex-component';
 
 import { graphql } from 'react-relay';
 import { type Side_info_QueryResponse } from './__generated__/Side_info_Query.graphql';
@@ -28,12 +27,17 @@ const StyledPageView = styled('div')`
 
 const Index = ({ props }: RenderProps) => {
   const { page, pages } = props;
-  const navitems = pages.map(page => ({
-    text: page.title || '',
-    href: '/info/[side]',
-    as: `/info/${page.slug}`,
-    key: page.id
-  }));
+  const navitems = pages
+    ? pages.map(
+        page =>
+          page && {
+            text: page.title || '',
+            href: '/info/[side]',
+            as: `/info/${page.slug}`,
+            key: page.id
+          }
+      )
+    : [];
   return (
     <>
       <StyledHeading>INFO</StyledHeading>
@@ -43,16 +47,7 @@ const Index = ({ props }: RenderProps) => {
           <PageView page={page} />
         </StyledPageView>
       ) : (
-        <>
-          <Flex center full>
-            <FlexItem>
-              <CenterIt text>
-                <h1>Finner ikke siden :( </h1>
-                <h2>404 Errr</h2>
-              </CenterIt>
-            </FlexItem>
-          </Flex>
-        </>
+        <ServerError statusCode={404} errorCode="ENOENT" />
       )}
     </>
   );

--- a/pages/jobb.js
+++ b/pages/jobb.js
@@ -59,7 +59,8 @@ export default withData(withRouter(Index), {
     fromYear: parseInt(router.query.fromYear, 10) || 1,
     toYear: parseInt(router.query.toYear, 10) || 5,
     company: router.query.company || '',
-    towns: parseTowns(router.query).map(el => el.value),
+    towns:
+      parseTowns(router.query) && parseTowns(router.query).map(el => el.value),
     orderBy: router.query.orderBy ? [router.query.orderBy, 'ID'] : [],
     count: 30
   })

--- a/pages/jobb/[slug].js
+++ b/pages/jobb/[slug].js
@@ -4,12 +4,12 @@ import React from 'react';
 import withData, { type WithDataProps } from '../../lib/withData';
 
 import { graphql } from 'react-relay';
-import { type Id_jobbannonse_QueryResponse } from './__generated__/Id_jobbannonse_Query.graphql';
+import { type Slug_jobbannonse_QueryResponse } from './__generated__/Slug_jobbannonse_Query.graphql';
 
 import Layout from '../../components/Layout';
 import JoblistingView from '../../components/Joblistings/JoblistingView';
 
-type RenderProps = WithDataProps<Id_jobbannonse_QueryResponse>;
+type RenderProps = WithDataProps<Slug_jobbannonse_QueryResponse>;
 
 const Index = ({ error, props }: RenderProps) => (
   <Layout
@@ -45,22 +45,20 @@ const Index = ({ error, props }: RenderProps) => (
 
 export default withData(Index, {
   query: graphql`
-    query Id_jobbannonse_Query($id: ID!) {
-      joblisting: node(id: $id) {
-        ... on Joblisting {
-          ...JoblistingView_joblisting
-          title
+    query Slug_jobbannonse_Query($slug: String!) {
+      joblisting: joblisting(slug: $slug) {
+        ...JoblistingView_joblisting
+        title
+        description
+        sharingImage
+        company {
           description
-          sharingImage
-          company {
-            description
-            name
-          }
+          name
         }
       }
     }
   `,
-  variables: ({ query: { id } }) => ({
-    id
+  variables: ({ query: { slug } }) => ({
+    slug
   })
 });

--- a/pages/jobb/[slug].js
+++ b/pages/jobb/[slug].js
@@ -7,6 +7,7 @@ import { graphql } from 'react-relay';
 import { type Slug_jobbannonse_QueryResponse } from './__generated__/Slug_jobbannonse_Query.graphql';
 
 import Layout from '../../components/Layout';
+import ServerError from '../../lib/ServerError';
 import JoblistingView from '../../components/Joblistings/JoblistingView';
 
 type RenderProps = WithDataProps<Slug_jobbannonse_QueryResponse>;
@@ -34,10 +35,11 @@ const Index = ({ error, props }: RenderProps) => (
       props.joblisting ? (
         <JoblistingView joblisting={props.joblisting} />
       ) : (
-        <>
-          <h1>Finner ikke siden :( </h1>
-          <h2>404 Errr</h2>
-        </>
+        <ServerError
+          errorCode="ENOENT"
+          statusCode={404}
+          title="Fant ikke jobbannonsen"
+        />
       )
     }
   />

--- a/pages/jobbannonse.js
+++ b/pages/jobbannonse.js
@@ -6,19 +6,18 @@ import Router from 'next/router';
 // For client redirects
 const Redirect = props => {
   useEffect(() => {
-    Router.replace(props.newLink, props.newLocation);
-  }, [props.newLink, props.newLocation]);
+    Router.replace(props.newLocation);
+  }, [props.newLocation]);
   return null;
 };
 
 // For SSR redirects
 Redirect.getInitialProps = ({ res, query }) => {
-  const newLocation = `/jobb/${query.id}`;
-  const newLink = '/jobb/[id]';
+  const newLocation = '/jobb';
   if (res) {
     res.writeHead(301, { Location: newLocation });
     res.end();
   }
-  return { newLocation, newLink };
+  return { newLocation };
 };
 export default Redirect;


### PR DESCRIPTION
- Adds a secondary navbar to `/info/[side]` page.
- Rename INFO to OM ITDAGENE and FOR BEDRIFTER to INFO.
- Adds a custom error page for rendering 404, 500 etc. Also adds a component for serving 404 (or other errors) from the ssr, `ServerError`.

TODO:
- [x] Use the new joblisting slugs instead of id in `/jobb/[id]`
- [x] Finish styling  

Requires https://github.com/itdagene-ntnu/itdagene/pull/111


_How it looks currently (feedback appreciated!)_ : (the links that should not be there will be removed by the required backend pr)
![image](https://user-images.githubusercontent.com/42850232/72688853-a65ccc80-3b0b-11ea-9181-5b5b251c0d61.png)
