### PR TITLE
Create a announcement-banner for the postpone due to Covid-19

### DIFF
--- a/components/Frontpage/AnnouncementBanner.tsx
+++ b/components/Frontpage/AnnouncementBanner.tsx
@@ -19,17 +19,22 @@ const AnnouncementBanner = () => {
           </Svg>
           <Info>
             <StyledHeader>
-              itDAGENE 2020 er dessverre utsatt grunnet Covid-19
+              itDAGENE 2020 er dessverre utsatt til{' '}
+              <StyledSpan>18. & 19. januar</StyledSpan> grunnet Covid-19
             </StyledHeader>
           </Info>
         </StyledRow>
-        <Link href="/info/covid-19">
+        <Link href="/info/[side]" as="info/covid-19">
           <StyledLink>Les mer</StyledLink>
         </Link>
       </InfoContainer>
     </AnnouncementContainer>
   );
 };
+
+const StyledSpan = styled.span`
+  text-decoration: underline;
+`;
 
 const StyledRow = styled.div`
   display: flex;

--- a/components/Frontpage/AnnouncementBanner.tsx
+++ b/components/Frontpage/AnnouncementBanner.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import styled from 'styled-components';
+import Link from 'next/link';
+
+const AnnouncementBanner = () => {
+  return (
+    <AnnouncementContainer>
+      <InfoContainer>
+        <StyledRow>
+          <Svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="white"
+            width="150px"
+            height="90px"
+          >
+            <path d="M0 0h24v24H0V0z" fill="none" />
+            <path d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z" />
+          </Svg>
+          <Info>
+            <StyledHeader>
+              itDAGENE 2020 er dessverre utsatt grunnet Covid-19
+            </StyledHeader>
+          </Info>
+        </StyledRow>
+        <Link href="/info/covid-19">
+          <StyledLink>Les mer</StyledLink>
+        </Link>
+      </InfoContainer>
+    </AnnouncementContainer>
+  );
+};
+
+const StyledRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+`;
+
+const AnnouncementContainer = styled.div`
+  display: flex;
+  /* width: 100%; */
+  border-radius: 30px;
+  margin: 20px;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  box-shadow: 0px 0px 8px 3px rgba(0, 0, 0, 0.1);
+  background-image: repeating-linear-gradient(
+    -45deg,
+    #f7ce3b,
+    #f7ce3b 35px,
+    #f4c20a 35px,
+    #f4c20a 70px
+  );
+`;
+
+const Info = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  flex-grow: 10;
+  text-align: center;
+`;
+
+const Svg = styled.svg`
+  flex-grow: 1;
+`;
+
+const InfoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 15px 15px 10px 15px;
+`;
+
+const StyledLink = styled.a`
+  color: white;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+`;
+
+const StyledHeader = styled.h1`
+  color: white;
+  font-weight: 700;
+`;
+
+export default AnnouncementBanner;

--- a/components/Frontpage/WelcomeScreen.tsx
+++ b/components/Frontpage/WelcomeScreen.tsx
@@ -94,15 +94,14 @@ const WelcomeScreen = ({ currentMetaData }: Props): JSX.Element => {
               <b>it</b>DAGENE {currentMetaData.year}
             </Header>
             <SubHeader>
-              Ny dato annonseres fortløpende
-              {/* {`${startDate.date()}. & ${endDate.date()}. ${endDate
-              .locale('nb')
-              .format('MMMM')} ${startDate.year()}`} */}
+              {`${startDate.date()}. & ${endDate.date()}. ${endDate
+                .locale('nb')
+                .format('MMMM')} ${startDate.year()}`}
             </SubHeader>
             <Location>NTNU // Realfagsbygget</Location>
           </FlexItem>
           <FlexItem>
-            {/* <Countdown currentMetaData={currentMetaData} /> */}
+            <Countdown currentMetaData={currentMetaData} />
           </FlexItem>
         </Flex>
 

--- a/components/Frontpage/WelcomeScreen.tsx
+++ b/components/Frontpage/WelcomeScreen.tsx
@@ -93,13 +93,16 @@ const WelcomeScreen = ({ currentMetaData }: Props): JSX.Element => {
             <Header>
               <b>it</b>DAGENE {currentMetaData.year}
             </Header>
-            <SubHeader>{`${startDate.date()}. & ${endDate.date()}. ${endDate
+            <SubHeader>
+              Ny dato annonseres fortløpende
+              {/* {`${startDate.date()}. & ${endDate.date()}. ${endDate
               .locale('nb')
-              .format('MMMM')} ${startDate.year()}`}</SubHeader>
+              .format('MMMM')} ${startDate.year()}`} */}
+            </SubHeader>
             <Location>NTNU // Realfagsbygget</Location>
           </FlexItem>
           <FlexItem>
-            <Countdown currentMetaData={currentMetaData} />
+            {/* <Countdown currentMetaData={currentMetaData} /> */}
           </FlexItem>
         </Flex>
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -16,6 +16,7 @@ import Interest from '../components/Frontpage/Interest';
 import { withDataAndLayout, WithDataAndLayoutProps } from '../lib/withData';
 import PageView from '../components/PageView';
 import CompactProgram from '../components/CompactProgram';
+import AnnouncementBanner from '../components/Frontpage/AnnouncementBanner';
 
 type RenderProps = WithDataAndLayoutProps<pages_index_QueryResponse>;
 
@@ -85,6 +86,7 @@ const EventsSection = ({
 
 const Index = ({ props, error }: RenderProps): JSX.Element => (
   <>
+    <AnnouncementBanner />
     <WelcomeScreen currentMetaData={props.currentMetaData} />
     <Section>
       <AboutSection {...props} />


### PR DESCRIPTION
The "Les mer" hits `/info/covid-19` - remember to activate the page named `Covid-19` in admin, before deploying this.

<br/>

![image](https://user-images.githubusercontent.com/27623888/85878946-cfc80580-b7d9-11ea-9aa6-b689fcdcbf7e.png)
