### PR TITLE
Remove unused dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@zeit/next-source-maps": "^0.0.4-canary.1",
     "babel-polyfill": "^6.26.0",
     "dayjs": "^1.9.3",
-    "express": "^4.17.1",
     "graphql": "^14.6.0",
     "isomorphic-unfetch": "^3.0.0",
     "lodash": "^4.17.20",
@@ -42,12 +41,10 @@
     "react-relay": "9.1.0",
     "react-responsive-carousel": "^3.2.9",
     "react-select": "^3.1.0",
-    "recompose": "0.30.0",
     "relay-hooks": "3.5.0",
     "relay-runtime": "9.1.0",
     "styled-components": "^4.4.1",
     "styled-flex-component": "^3.0.2",
-    "trim-right": "^1.0.1",
     "video-react": "^0.14.1"
   },
   "browser": {
@@ -91,8 +88,7 @@
     "react-test-renderer": "16.13.1",
     "relay-compiler": "9.1.0",
     "relay-compiler-language-typescript": "^12.0.3",
-    "typescript": "^3.9.7",
-    "webpack": "^4.42.1"
+    "typescript": "^3.9.7"
   },
   "prettier": {
     "singleQuote": true


### PR DESCRIPTION
- `webpack` is handled by next
- `recompose` is unused in addition to not needed with react hooks.
- `express` was used to proxy `/graphql`. This was removed some time ago, as it is not necessary.
- `trim-right` :shrug: Not used anywhere.