### PR TITLE
Add video embedding to stand detail

### DIFF
--- a/components/Stands/AboutStand.tsx
+++ b/components/Stands/AboutStand.tsx
@@ -1,12 +1,53 @@
 import React from 'react';
+import Link from 'next/link';
 import Loading from '../LoadingIndicator';
 import ReactMarkdown from 'react-markdown';
+import { Player, BigPlayButton } from 'video-react';
+import styled from 'styled-components';
 import { graphql, useFragment } from 'relay-hooks';
 import { AboutStand_stand$key } from '../../__generated__/AboutStand_stand.graphql';
+
+const VIDEO_REGEX = /https:\/\/cdn\.itdagene\.no\/([a-zA-Z0-9]+\/?)*.(mp4|mkv|webm)/;
 
 type Props = {
   stand: AboutStand_stand$key;
 };
+
+const PlayerWrapper = styled.div`
+  width: 50%;
+  @media only screen and (max-width: 991px) {
+    width: 100%;
+  }
+`;
+
+const LinkRenderer = ({
+  href,
+  children,
+}: {
+  href: string;
+  children: React.ReactNode;
+}): JSX.Element => {
+  if (href.startsWith('/')) {
+    return (
+      <Link href={href}>
+        <a> {children}</a>
+      </Link>
+    );
+  }
+  // If the url matches a video on our cdn, render it.
+  if (VIDEO_REGEX.test(href)) {
+    return (
+      <PlayerWrapper>
+        <Player src={href}>
+          <BigPlayButton position="center" />
+        </Player>
+      </PlayerWrapper>
+    );
+  }
+  return <a href={href}> {children}</a>;
+};
+
+const renderers = { link: LinkRenderer };
 
 const AboutStand = (props: Props): JSX.Element => {
   const about = useFragment(
@@ -19,7 +60,7 @@ const AboutStand = (props: Props): JSX.Element => {
   );
 
   return about ? (
-    <ReactMarkdown>{about.description}</ReactMarkdown>
+    <ReactMarkdown renderers={renderers}>{about.description}</ReactMarkdown>
   ) : (
     <Loading />
   );


### PR DESCRIPTION
Depends on #522.

Slightly hacky solution to be able to render videos in stand detail. I did not do this generally for all markdown content since we don't seem to have a general component for all markdown (todo @itdagene-ntnu/2021).

The renderer uses markdown links to render links with videos hosted on our cdn with video-react.

I made this since there were some questions about embedding videos with the stand beside the livestream.