### PR TITLE
Fix padding on eventsection on frontpage

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -66,7 +66,12 @@ const EventsSection = ({
         query.pages.filter(Boolean).map(
           (element) =>
             element && (
-              <FlexItem key={element.slug} basis={'400px'} grow={1}>
+              <FlexItem
+                key={element.slug}
+                basis={'400px'}
+                grow={1}
+                style={{ paddingRight: '1em' }}
+              >
                 <h2> {element.title} </h2>
                 <p>{element.ingress}</p>
                 <Centered>


### PR DESCRIPTION
From this: 
![image](https://user-images.githubusercontent.com/55149662/131004394-614f8a98-9154-4d99-9999-cf50884fbedf.png)

To this: 
![image](https://user-images.githubusercontent.com/55149662/131004426-77641086-6630-4227-b821-4c590263e77a.png)
