### PR TITLE
Add new date at welcome page

### DIFF
--- a/components/Frontpage/WelcomeScreen.tsx
+++ b/components/Frontpage/WelcomeScreen.tsx
@@ -92,7 +92,7 @@ const WelcomeScreen = ({ currentMetaData }: Props): JSX.Element => {
         <Flex column contentSpaceBetween>
           <FlexItem>
             <Header>
-              <b>it</b>DAGENE {currentMetaData.year}
+              <b>it</b>DAGENE 2023
             </Header>
 
             <SubHeader>


### PR DESCRIPTION
Changed the current date at welcome page to 2023. Should be changes back to currentMetaData after new year.