### PR TITLE
Slightly improve design of collaborators list

### DIFF
--- a/components/Collaborators/Collaborator.tsx
+++ b/components/Collaborators/Collaborator.tsx
@@ -46,7 +46,7 @@ const Collaborator = ({
 
   return (
     <div
-      style={{ flex: 1, maxWidth: '100%', flexBasis: 350, padding: '0 10px' }}
+      style={{ flex: 1, maxWidth: '100%', flexBasis: 450, padding: '0 10px' }}
     >
       <a href={company.url || ''} target="_blank" rel="noreferrer">
         <Image src={company.logo || ''} />

--- a/components/Collaborators/Collaborators.tsx
+++ b/components/Collaborators/Collaborators.tsx
@@ -23,7 +23,7 @@ const Collaborators = ({
   query.collaborators ? (
     <>
       <Title>Våre samarbeidspartnere</Title>
-      <Flex flexWrap="wrap" justifyContent="center">
+      <Flex flexWrap="wrap" justifyContent="center" gap="2em">
         {query.collaborators.map((company) => (
           <CollaboratorView
             showJoblistings={showJoblistings}

--- a/components/Collaborators/MainCollaborator.tsx
+++ b/components/Collaborators/MainCollaborator.tsx
@@ -21,11 +21,11 @@ const Image = styled(ZoomImage)`
   height: 103px;
   max-width: calc(100% - 30px);
   object-fit: cover;
-  margin: 40px auto 0 auto;
   padding: 15px;
 `;
 
 const Title = styled('h1')`
+  margin: 0;
   @media only screen and (max-width: 767px) {
     font-size: 1.5em;
   }
@@ -47,7 +47,7 @@ const fragmentSpec = graphql`
 const HSPLogo = styled(Image)`
   width: 450px;
   max-width: 100%;
-  margin-top: 10px;
+  margin: 20px auto;
 `;
 
 const MainCollaborator = ({
@@ -73,7 +73,7 @@ const MainCollaborator = ({
           </a>
         </FlexItem>
         <CenterIt text>
-          <p>
+          <p style={{ fontSize: 20 }}>
             <b>
               Vi er stolte av å kunne presentere {company.name} som
               hovedsamarbeidspartner!
@@ -84,14 +84,13 @@ const MainCollaborator = ({
 
           {company.intro && <ReactMarkdown source={company.intro} />}
 
-          <h3>
-            ↓ Ta en titt på hvordan sommerjobb i {company.name} kan se ut ↓
-          </h3>
-
-          {company.video ? (
-            <Player playsInline poster={company.logo} src={company.video} />
-          ) : (
-            'Missing main collaborator video!'
+          {company.video && (
+            <>
+              <h3>
+                ↓ Ta en titt på hvordan sommerjobb i {company.name} kan se ut ↓
+              </h3>
+              <Player playsInline poster={company.logo} src={company.video} />
+            </>
           )}
         </CenterIt>
       </FlexItem>


### PR DESCRIPTION
Just fixing some annoying design. 

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            The "ta en titt..." should not appear if there is no video and there was a bit weird spacing with the logo
        </td>
        <td>
<img width="1656" alt="Screenshot 2024-05-26 at 22 11 49" src="https://github.com/itdagene-ntnu/itdagene-webapp/assets/45620425/3e17fbe2-cc26-4456-aaf2-07b5ec5a983c">
        </td>
        <td>
            <img width="1536" alt="Screenshot 2024-05-26 at 22 09 59" src="https://github.com/itdagene-ntnu/itdagene-webapp/assets/45620425/4b69236b-d329-4187-9f20-e54708c56c61">
        </td>
    </tr>
    <tr>
        <td>
            With 4 collaborators the default amount of columns should be 2
        </td>
        <td>
<img width="1816" alt="Screenshot 2024-05-26 at 22 14 19" src="https://github.com/itdagene-ntnu/itdagene-webapp/assets/45620425/7a20e2a1-fb16-4d55-a564-0657d7482ee2">
        </td>
        <td>
<img width="1541" alt="Screenshot 2024-05-26 at 22 14 01" src="https://github.com/itdagene-ntnu/itdagene-webapp/assets/45620425/2f710207-119c-4c52-8c3c-5bf255b3d977">
        </td>
    </tr>
</table>


Since the collaborators list is just a flexbox and all I did was change the default size for each item, please check that it looks good on other viewports aswell, im only pretty sure it does :)

Do we want to center the text within each collaborator description? In that case it has to be done in the admin panel with markdown. 
