### PR TITLE
Remove LastUpdate from PageView

### DIFF
--- a/components/PageView/index.tsx
+++ b/components/PageView/index.tsx
@@ -10,7 +10,6 @@ import { Player } from 'video-react';
 
 type Props = {
   page: PageView_page;
-  hideDate?: boolean;
   hideContent?: boolean;
   hideTitle?: boolean;
 };
@@ -20,16 +19,6 @@ const Title = styled('h1')`
   font-smoothing: antialiased;
   font-size: 3rem;
   margin-bottom: 1rem;
-`;
-
-const LastUpdate = styled('div')`
-  font-weight: bold;
-  font-family: Roboto;
-  font-size: 0.8rem;
-  color: #222;
-  text-transform: uppercase;
-  letter-spacing: 1.25px;
-  margin-bottom: 1.5rem;
 `;
 
 const LinkRenderer = ({
@@ -48,28 +37,10 @@ const LinkRenderer = ({
 
 const renderers = { link: LinkRenderer };
 
-const PageView = ({
-  page,
-  hideDate,
-  hideContent,
-  hideTitle,
-}: Props): JSX.Element => {
-  const style = {
-    position: 'absolute' as 'absolute',
-    top: '50%',
-    left: '50%',
-    transform: 'translate(-50%, -50%)',
-    boxShadow: 24,
-    p: 1,
-  };
+const PageView = ({ page, hideContent, hideTitle }: Props): JSX.Element => {
   return (
     <>
       {!hideTitle && <Title>{page.title}</Title>}
-      {!hideDate && (
-        <LastUpdate>
-          {dayjs(page.dateSaved as string).format(`DD. MMMM, YYYY`)}
-        </LastUpdate>
-      )}
       {!hideContent && (
         <Flex flexDirection="column">
           <ReactMarkdown renderers={renderers} source={page.content} />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -41,7 +41,7 @@ const AboutSection = (props: pages_index_QueryResponse): JSX.Element => {
         style={{ alignItems: 'center', gap: '2em' }}
       >
         <FlexItem flexBasis="700px" flexGrow="1">
-          {frontpage && <PageView hideDate page={frontpage} />}
+          {frontpage && <PageView page={frontpage} />}
         </FlexItem>
 
         <CustomPlayer>

--- a/pages/program.tsx
+++ b/pages/program.tsx
@@ -15,9 +15,7 @@ const Index = ({
   <>
     {props.programPage && <PageView hideContent page={props.programPage} />}
 
-    {props.programPage && (
-      <PageView hideTitle hideDate page={props.programPage} />
-    )}
+    {props.programPage && <PageView hideTitle page={props.programPage} />}
 
     {props.events ? (
       <ProgramView

--- a/pages/stands/index.tsx
+++ b/pages/stands/index.tsx
@@ -126,7 +126,7 @@ const Index = ({
     <>
       {props.stands_page && (
         <BorderlessSection noPadding>
-          <PageView hideDate hideTitle page={props.stands_page} />
+          <PageView hideTitle page={props.stands_page} />
         </BorderlessSection>
       )}
 


### PR DESCRIPTION
I know there was some talk about removing these since they appeared confusing as to what the date actually meant. 

So heres a PR if we want to remove it. Potentially we could add "Sist opdatert: " text to make it more clear what it means instead of completely removing it. What do you think?

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>

![Screenshot 2024-05-28 at 17 01 31](https://github.com/itdagene-ntnu/itdagene-webapp/assets/45620425/136ada74-f050-43ef-8aba-00e909252acf)
        </td>
        <td>

![Screenshot 2024-05-28 at 17 01 50](https://github.com/itdagene-ntnu/itdagene-webapp/assets/45620425/5353f101-86ee-4532-9b83-aa4101ec143d)
       </td>
    </tr>
</table>