### PR TITLE
Changed button at frontpage to redirect to Gallery instead of Banquet

### DIFF
--- a/components/CompactProgram/index.tsx
+++ b/components/CompactProgram/index.tsx
@@ -78,9 +78,9 @@ const CompactProgram = (): JSX.Element => (
         </Link>
       </Tile>
       <Tile color={indigoDye}>
-        <Link href="/info/bankett" legacyBehavior>
+        <Link href="/galleri" legacyBehavior>
           <CenterIt text>
-            <StyledLink>Bankett</StyledLink>
+            <StyledLink>Galleri</StyledLink>
           </CenterIt>
         </Link>
       </Tile>


### PR DESCRIPTION
Before:
<img width="1182" alt="Skjermbilde 2025-02-14 kl  12 58 38" src="https://github.com/user-attachments/assets/b07e8ac9-f25a-4216-aa4f-c70fe57127b6" />
After:
<img width="1187" alt="Skjermbilde 2025-02-14 kl  12 59 56" src="https://github.com/user-attachments/assets/d6694fe3-900c-4990-99c3-1e0e31ff8f1b" />
