### PR TITLE
linking to gallery instead of banquet on front page

### DIFF
--- a/components/CompactProgram/index.tsx
+++ b/components/CompactProgram/index.tsx
@@ -78,9 +78,9 @@ const CompactProgram = (): JSX.Element => (
         </Link>
       </Tile>
       <Tile color={indigoDye}>
-        <Link href="/info/bankett" legacyBehavior>
+        <Link href="/gallery" legacyBehavior>
           <CenterIt text>
-            <StyledLink>Bankett</StyledLink>
+            <StyledLink>Galleri</StyledLink>
           </CenterIt>
         </Link>
       </Tile>


### PR DESCRIPTION
Before:
<img width="1245" alt="Skjermbilde 2025-03-14 kl  13 01 46" src="https://github.com/user-attachments/assets/98e18693-55bf-40f8-bc31-2c6abf721e97" />
After:
<img width="1200" alt="Skjermbilde 2025-03-14 kl  13 01 40" src="https://github.com/user-attachments/assets/52900f46-2d87-423a-a3c2-70a3f12a2c8a" />
