### PR TITLE
Chore: Remove interest deadline

### DIFF
--- a/components/Frontpage/Interest.tsx
+++ b/components/Frontpage/Interest.tsx
@@ -38,8 +38,7 @@ const Interest = ({ form }: Props): JSX.Element => (
       <FlexItem flexBasis="700px" flexGrow="1">
         <Title>Interessert i å delta? </Title>
         <p>
-          Interesseskjemaet for itDAGENE 2025 er nå åpent. Frist for å melde
-          interesse er <b>16. mars 2025</b>. Vi ønsker å påpeke at dette kun er
+          Interesseskjemaet for itDAGENE 2025 er nå åpent. Vi ønsker å påpeke at dette kun er
           for å kartlegge interesse og at det ikke er et påmeldingsskjema. Under
           finner dere en lenke til vårt nye interesseskjema hvor din bedrift kan
           melde sin interesse for itDAGENE 2025.


### PR DESCRIPTION
**Before:**
Interesseskjemaet for itDAGENE 2025 er nå åpent. Frist for å melde interesse er 16. mars 2025. Vi ønsker å påpeke at dette kun er for å kartlegge interesse og at det ikke er et påmeldingsskjema. Under finner dere en lenke til vårt nye interesseskjema hvor din bedrift kan melde sin interesse for itDAGENE 2025.

**After:**
  Interesseskjemaet for itDAGENE 2025 er nå åpent. Vi ønsker å påpeke at dette kun er
  for å kartlegge interesse og at det ikke er et påmeldingsskjema. Under
  finner dere en lenke til vårt nye interesseskjema hvor din bedrift kan
  melde sin interesse for itDAGENE 2025.