### PR TITLE
Update stand map images and CDN content on server

### DIFF
--- a/pages/stands/index.tsx
+++ b/pages/stands/index.tsx
@@ -26,21 +26,23 @@ const StandImage = styled.img`
 const Index = (): JSX.Element => {
   return (
     <>
+      {/*
       <Title>Stands</Title>
       <InfoIngress>Oversikt over standplasser</InfoIngress>
       <StandImage src="/static/standkart_uten_bedrifter.png" />
+      /*}
       {/* Fjern kommentar når standsoversikt er ferdig */}
-      {/* <Title>Stands</Title>
+      <Title>Stands</Title>
       <DateTitle>Mandag</DateTitle>
       <StandImage
-        src="https://cdn.itdagene.no/mandag_oppdatert.png"
+        src="https://cdn.itdagene.no/standkart_mandag.png"
         alt="Stands mandag"
       />
       <DateTitle>Tirsdag</DateTitle>
       <StandImage
-        src="https://cdn.itdagene.no/stands_tirsdag.png"
+        src="https://cdn.itdagene.no/standkart_tirsdag.png"
         alt="Stands tirsdag"
-      /> */}
+      />
     </>
   );
 };


### PR DESCRIPTION
uploaded this years stand map, made frontend get correct images

Before:
<img width="1112" height="867" alt="image" src="https://github.com/user-attachments/assets/6554dadf-7883-413a-bbad-1ceddc8e911f" />


After:
<img width="1112" height="867" alt="image" src="https://github.com/user-attachments/assets/2c82518a-7ca4-4959-9753-44553a5f05ef" />
<img width="1112" height="867" alt="image" src="https://github.com/user-attachments/assets/dd87a070-de9a-4963-b78f-31350cd7dd02" />
