### PR TITLE
fix: refine responsive homepage navigation

### DIFF
--- a/__tests__/e2e.js
+++ b/__tests__/e2e.js
@@ -369,6 +369,9 @@ describe('Page rendering', () => {
       const planner = document.querySelector('.visit-planner');
       const marquee = document.querySelector('[data-testid="event-marquee"]');
       const invitation = document.querySelector('.employer-invitation');
+      const mobileSwitcher = document.querySelector(
+        '.homepage-company-sections__switcher'
+      );
       // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
       const comesBefore = (first, second) =>
         Boolean(
@@ -395,6 +398,9 @@ describe('Page rendering', () => {
         hasHiddenCompanyControls: Boolean(
           directory?.querySelector('details, [role="tab"]')
         ),
+        mobileSwitcherHidden:
+          !mobileSwitcher ||
+          getComputedStyle(mobileSwitcher).display === 'none',
         historicalMarqueePublished: Boolean(marquee),
         marqueeAfterPlanner: marquee ? comesBefore(planner, marquee) : false,
         marqueeBeforeInvitation: comesBefore(marquee, invitation),
@@ -430,6 +436,7 @@ describe('Page rendering', () => {
       expect(exposure.companyCount).toBeGreaterThan(0);
       expect(exposure.visibleCompanies).toBe(true);
       expect(exposure.hasHiddenCompanyControls).toBe(false);
+      expect(exposure.mobileSwitcherHidden).toBe(true);
       expect(exposure.externalLinksValid).toBe(true);
       expect(exposure.standsHref).toBe('/stands');
     } else {
@@ -439,28 +446,108 @@ describe('Page rendering', () => {
   }, 16000);
 
   test('Company exposure is contained on mobile', async () => {
-    await page.setViewport({ width: 390, height: 844 });
+    await page.setViewport({ width: 320, height: 844 });
     await page.goto(baseUrl);
 
     const region = await page.$('[data-testid="event-marquee"]');
 
     if (!region) {
       expect(await page.$('.current-company-directory')).not.toBeNull();
-      expect(
-        await page.evaluate(() => ({
+      const mobileExposure = await page.evaluate(() => {
+        const switcher = document.querySelector(
+          '.homepage-company-sections__switcher'
+        );
+        const buttons = [...switcher.querySelectorAll('button')];
+        const partnerPanel = document.querySelector(
+          '[data-company-mobile-panel="partners"]'
+        );
+        const dayLabels = [
+          ...document.querySelectorAll('[data-company-day] h3'),
+        ].map((heading) => heading.textContent.trim().split(' ')[0]);
+        const controlRect = switcher
+          .querySelector('.segmented-control')
+          .getBoundingClientRect();
+        const activeRect = switcher
+          .querySelector('[data-active="true"]')
+          .getBoundingClientRect();
+        return {
+          activeSegmentFits:
+            activeRect.top - controlRect.top <= 1 &&
+            controlRect.bottom - activeRect.bottom <= 1,
+          buttonLabels: buttons.map((button) => button.textContent.trim()),
+          buttonTextContained: buttons.every(
+            (button) => button.scrollWidth <= button.clientWidth + 1
+          ),
+          controlsValid: buttons.every((button) => {
+            const controlledId = button.getAttribute('aria-controls');
+            return controlledId && document.getElementById(controlledId);
+          }),
           documentOverflow:
             document.documentElement.scrollWidth >
             document.documentElement.clientWidth,
-          gridColumns: getComputedStyle(
-            document.querySelector('.current-company-directory__grid')
-          ).gridTemplateColumns.split(' ').length,
+          expectedLabels: [
+            ...(partnerPanel ? ['Samarbeidspartnere'] : []),
+            ...dayLabels,
+          ],
+          pressedCount: buttons.filter(
+            (button) => button.getAttribute('aria-pressed') === 'true'
+          ).length,
+          switcherDisplay: getComputedStyle(switcher).display,
+          visiblePanels: [
+            ...document.querySelectorAll('[data-company-mobile-panel]'),
+          ]
+            .filter((panel) => getComputedStyle(panel).display !== 'none')
+            .map((panel) => panel.dataset.companyMobilePanel),
+        };
+      });
+
+      expect(mobileExposure.buttonLabels).toEqual(
+        mobileExposure.expectedLabels
+      );
+      expect(mobileExposure.activeSegmentFits).toBe(true);
+      expect(mobileExposure.buttonTextContained).toBe(true);
+      expect(mobileExposure.controlsValid).toBe(true);
+      expect(mobileExposure.documentOverflow).toBe(false);
+      expect(mobileExposure.pressedCount).toBe(1);
+      expect(mobileExposure.switcherDisplay).not.toBe('none');
+      expect(mobileExposure.visiblePanels).toEqual([
+        mobileExposure.buttonLabels[0] === 'Samarbeidspartnere'
+          ? 'partners'
+          : 'directory',
+      ]);
+
+      await page.focus(
+        '.homepage-company-sections__switcher button[aria-controls="homepage-company-directory"]'
+      );
+      await page.keyboard.press('Space');
+      expect(
+        await page.evaluate(() => ({
+          visibleDay: document.querySelector(
+            '.current-company-directory__day[data-mobile-active="true"]'
+          ).dataset.companyDay,
+          visiblePanels: [
+            ...document.querySelectorAll('[data-company-mobile-panel]'),
+          ]
+            .filter((panel) => getComputedStyle(panel).display !== 'none')
+            .map((panel) => panel.dataset.companyMobilePanel),
         }))
       ).toEqual({
-        documentOverflow: false,
-        gridColumns: 2,
+        visibleDay: 'first',
+        visiblePanels: ['directory'],
       });
+
+      await page.keyboard.press('Tab');
+      await page.keyboard.press('Space');
+      expect(
+        await page.$eval(
+          '.current-company-directory__day[data-mobile-active="true"]',
+          (day) => day.dataset.companyDay
+        )
+      ).toBe('last');
       return;
     }
+
+    expect(await page.$('.homepage-company-sections__switcher')).toBeNull();
 
     expect(
       await page.$eval('[data-testid="event-marquee"]', (marquee) => {
@@ -491,6 +578,50 @@ describe('Page rendering', () => {
     });
   }, 16000);
 
+  test('Visit planner stays aligned and contained on narrow screens', async () => {
+    for (const width of [320, 375, 390]) {
+      await page.setViewport({ width, height: 844 });
+      await page.goto(baseUrl);
+
+      const layout = await page.evaluate(() => {
+        const items = [...document.querySelectorAll('.visit-planner li')];
+        const headingOffsets = items.map((item) => {
+          const linkRect = item.querySelector('a').getBoundingClientRect();
+          const headingRect = item.querySelector('h3').getBoundingClientRect();
+          return Math.round(headingRect.top - linkRect.top);
+        });
+
+        return {
+          columns: getComputedStyle(
+            document.querySelector('.visit-planner ul')
+          ).gridTemplateColumns.split(' ').length,
+          headingOffsets,
+          statusOffsets: items
+            .filter((item) => item.querySelector('small'))
+            .map((item) => {
+              const linkRect = item.querySelector('a').getBoundingClientRect();
+              const statusRect = item
+                .querySelector('small')
+                .getBoundingClientRect();
+              return Math.round(statusRect.top - linkRect.top);
+            }),
+          textContained: items.every((item) =>
+            [...item.querySelectorAll('p, small')].every(
+              (text) => text.scrollWidth <= text.clientWidth + 1
+            )
+          ),
+        };
+      });
+
+      expect(layout.columns).toBe(width <= 340 ? 1 : 2);
+      expect(new Set(layout.headingOffsets).size).toBe(1);
+      if (width > 340) {
+        expect(new Set(layout.statusOffsets).size).toBe(1);
+      }
+      expect(layout.textContained).toBe(true);
+    }
+  }, 24000);
+
   test('Visit planner hover covers each card with its route tint', async () => {
     await page.setViewport({ width: 1440, height: 900 });
     await page.goto(baseUrl);
@@ -499,6 +630,29 @@ describe('Page rendering', () => {
         document.querySelector('.event-hero-story')?.dataset.heroTransition ===
         'ready'
     );
+
+    const desktopAlignment = await page.evaluate(() => {
+      const cards = [...document.querySelectorAll('.visit-planner li')];
+      // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+      const relativeTop = (card, selector) => {
+        const cardTop = card.querySelector('a').getBoundingClientRect().top;
+        return Math.round(
+          card.querySelector(selector).getBoundingClientRect().top - cardTop
+        );
+      };
+
+      return {
+        descriptionOffsets: cards.map((card) => relativeTop(card, 'p')),
+        headingOffsets: cards.map((card) => relativeTop(card, 'h3')),
+        statusOffsets: cards
+          .filter((card) => card.querySelector('small'))
+          .map((card) => relativeTop(card, 'small')),
+      };
+    });
+
+    expect(new Set(desktopAlignment.headingOffsets).size).toBe(1);
+    expect(new Set(desktopAlignment.descriptionOffsets).size).toBe(1);
+    expect(new Set(desktopAlignment.statusOffsets).size).toBe(1);
 
     const cardResults = [];
 

--- a/__tests__/e2e.js
+++ b/__tests__/e2e.js
@@ -2113,6 +2113,39 @@ describe('Page rendering', () => {
     ).toBe(false);
   }, 30000);
 
+  test('Homepage layout continues scaling on wide screens', async () => {
+    await page.setViewport({ width: 2560, height: 1440 });
+    await page.goto(baseUrl);
+
+    const layout = await page.evaluate(() => {
+      const sectionContainer = document.querySelector(
+        '.homepage .site-section .site-container'
+      );
+      const heroContent = document.querySelector('.event-hero__content');
+      const heroTitle = document.querySelector('.event-hero__resolved-title');
+      const countdown = document.querySelector('.event-countdown');
+
+      return {
+        countdownWidth: countdown.getBoundingClientRect().width,
+        documentOverflow:
+          document.documentElement.scrollWidth >
+          document.documentElement.clientWidth,
+        heroContentWidth: heroContent.getBoundingClientRect().width,
+        heroTitleFontSize: Number.parseFloat(
+          getComputedStyle(heroTitle).fontSize
+        ),
+        sectionWidth: sectionContainer.getBoundingClientRect().width,
+        viewportWidth: window.innerWidth,
+      };
+    });
+
+    expect(layout.documentOverflow).toBe(false);
+    expect(layout.sectionWidth / layout.viewportWidth).toBeGreaterThan(0.88);
+    expect(layout.heroContentWidth / layout.viewportWidth).toBeGreaterThan(0.4);
+    expect(layout.heroTitleFontSize).toBeGreaterThanOrEqual(120);
+    expect(layout.countdownWidth).toBeGreaterThanOrEqual(700);
+  }, 16000);
+
   test.each([
     ['/program', 'rgb(245, 130, 30)'],
     ['/stands', 'rgb(124, 209, 238)'],

--- a/components/DesignSystem/index.tsx
+++ b/components/DesignSystem/index.tsx
@@ -218,7 +218,7 @@ export const SegmentedControl = ({
   onChange,
   label,
 }: {
-  options: Array<{ value: string; label: string }>;
+  options: Array<{ value: string; label: string; controls?: string }>;
   activeValue: string;
   onChange: (value: string) => void;
   label: string;
@@ -226,6 +226,7 @@ export const SegmentedControl = ({
   <div aria-label={label} className="segmented-control" role="group">
     {options.map((option) => (
       <button
+        aria-controls={option.controls}
         aria-pressed={option.value === activeValue}
         className="segmented-control__item"
         data-active={option.value === activeValue}

--- a/components/Frontpage/CompanyExposure.tsx
+++ b/components/Frontpage/CompanyExposure.tsx
@@ -25,6 +25,7 @@ export const CompanyExposure = ({
   historicalItems,
   historicalLabel,
   lastDay,
+  mobileActiveDay,
   startDate,
 }: {
   edition: number;
@@ -34,6 +35,7 @@ export const CompanyExposure = ({
   historicalItems: CompanyMarqueeItem[];
   historicalLabel: string;
   lastDay: ReadonlyArray<DirectoryCompany> | null;
+  mobileActiveDay?: 'first' | 'last';
   startDate: string;
 }): JSX.Element => {
   const mode = resolveCompanyExposureMode({ firstDay, lastDay });
@@ -55,6 +57,7 @@ export const CompanyExposure = ({
           endDate={endDate}
           firstDay={firstDay}
           lastDay={lastDay}
+          mobileActiveDay={mobileActiveDay}
           startDate={startDate}
         />
       )}

--- a/components/Frontpage/CurrentCompanyDirectory.tsx
+++ b/components/Frontpage/CurrentCompanyDirectory.tsx
@@ -78,11 +78,13 @@ const CompanyDay = ({
   date,
   fallbackLabel,
   id,
+  mobileActive,
 }: {
   companies: ReadonlyArray<DirectoryCompany> | null;
   date: string;
   fallbackLabel: string;
   id: string;
+  mobileActive: boolean;
 }): JSX.Element => {
   const headingId = `company-day-${id}`;
   const sortedCompanies =
@@ -94,6 +96,7 @@ const CompanyDay = ({
       aria-labelledby={headingId}
       className="current-company-directory__day"
       data-company-day={id}
+      data-mobile-active={mobileActive}
       data-company-state={
         companies === null ? 'unpublished' : count === 0 ? 'empty' : 'published'
       }
@@ -138,12 +141,14 @@ export const CurrentCompanyDirectory = ({
   endDate,
   firstDay,
   lastDay,
+  mobileActiveDay = 'first',
   startDate,
 }: {
   edition: number;
   endDate: string;
   firstDay: ReadonlyArray<DirectoryCompany> | null;
   lastDay: ReadonlyArray<DirectoryCompany> | null;
+  mobileActiveDay?: 'first' | 'last';
   startDate: string;
 }): JSX.Element | null => {
   if (firstDay === null && lastDay === null) return null;
@@ -163,12 +168,14 @@ export const CurrentCompanyDirectory = ({
           date={startDate}
           fallbackLabel="Første messedag"
           id="first"
+          mobileActive={mobileActiveDay === 'first'}
         />
         <CompanyDay
           companies={lastDay}
           date={endDate}
           fallbackLabel="Andre messedag"
           id="last"
+          mobileActive={mobileActiveDay === 'last'}
         />
       </div>
     </SiteSection>

--- a/components/Frontpage/HomepageCompanySections.tsx
+++ b/components/Frontpage/HomepageCompanySections.tsx
@@ -1,0 +1,149 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { SegmentedControl, SiteContainer } from '../DesignSystem';
+import { CompanyMarqueeItem } from '../../utils/companyMarquee';
+import { CompanyExposure, resolveCompanyExposureMode } from './CompanyExposure';
+import { DirectoryCompany, formatCompanyDay } from './CurrentCompanyDirectory';
+import {
+  HomepageMainPartner,
+  HomepagePartner,
+  PartnerShowcase,
+} from './PartnerTiers';
+
+type MobileCompanySection = 'partners' | 'first' | 'last';
+
+export const HomepageCompanySections = ({
+  edition,
+  endDate,
+  firstDay,
+  historicalEdition,
+  historicalItems,
+  historicalLabel,
+  lastDay,
+  mainPartner,
+  partners,
+  startDate,
+}: {
+  edition: number;
+  endDate: string;
+  firstDay: ReadonlyArray<DirectoryCompany> | null;
+  historicalEdition: number;
+  historicalItems: CompanyMarqueeItem[];
+  historicalLabel: string;
+  lastDay: ReadonlyArray<DirectoryCompany> | null;
+  mainPartner?: HomepageMainPartner | null;
+  partners: ReadonlyArray<HomepagePartner>;
+  startDate: string;
+}): JSX.Element => {
+  const hasPartners = Boolean(mainPartner) || partners.length > 0;
+  const mode = resolveCompanyExposureMode({ firstDay, lastDay });
+  const initialSection: MobileCompanySection = hasPartners
+    ? 'partners'
+    : firstDay === null && lastDay !== null
+    ? 'last'
+    : 'first';
+  const [selectedSection, setSelectedSection] =
+    useState<MobileCompanySection>(initialSection);
+  const previousFirstDay = useRef(firstDay);
+  const previousLastDay = useRef(lastDay);
+  const fallbackDay: MobileCompanySection =
+    firstDay === null && lastDay !== null ? 'last' : 'first';
+  const removedSelectedDay: MobileCompanySection | undefined =
+    selectedSection === 'first' &&
+    previousFirstDay.current !== null &&
+    firstDay === null &&
+    lastDay !== null
+      ? 'last'
+      : selectedSection === 'last' &&
+        previousLastDay.current !== null &&
+        lastDay === null &&
+        firstDay !== null
+      ? 'first'
+      : undefined;
+  const activeSection = removedSelectedDay
+    ? removedSelectedDay
+    : selectedSection === 'partners' && !hasPartners
+    ? fallbackDay
+    : selectedSection;
+
+  useEffect(() => {
+    previousFirstDay.current = firstDay;
+    previousLastDay.current = lastDay;
+    if (activeSection !== selectedSection) {
+      setSelectedSection(activeSection);
+    }
+  }, [activeSection, firstDay, lastDay, selectedSection]);
+  const showMobileSelector = mode === 'current';
+  const options = [
+    ...(hasPartners
+      ? [
+          {
+            value: 'partners',
+            label: 'Samarbeidspartnere',
+            controls: 'homepage-company-partners',
+          },
+        ]
+      : []),
+    {
+      value: 'first',
+      label: formatCompanyDay(startDate, 'Første dag').split(' ')[0],
+      controls: 'homepage-company-directory',
+    },
+    {
+      value: 'last',
+      label: formatCompanyDay(endDate, 'Andre dag').split(' ')[0],
+      controls: 'homepage-company-directory',
+    },
+  ];
+
+  return (
+    <div
+      className="homepage-company-sections"
+      data-company-mobile-section={activeSection}
+    >
+      {showMobileSelector && (
+        <div className="homepage-company-sections__switcher">
+          <SiteContainer>
+            <SegmentedControl
+              activeValue={activeSection}
+              label="Velg bedriftsoversikt"
+              onChange={(value): void =>
+                setSelectedSection(value as MobileCompanySection)
+              }
+              options={options}
+            />
+          </SiteContainer>
+        </div>
+      )}
+
+      {hasPartners && (
+        <div
+          data-company-mobile-panel="partners"
+          data-mobile-active={activeSection === 'partners'}
+          id="homepage-company-partners"
+        >
+          <PartnerShowcase mainPartner={mainPartner} partners={partners} />
+        </div>
+      )}
+
+      <div
+        data-company-mobile-panel="directory"
+        data-mobile-active={
+          mode === 'historical' || activeSection !== 'partners'
+        }
+        id="homepage-company-directory"
+      >
+        <CompanyExposure
+          edition={edition}
+          endDate={endDate}
+          firstDay={firstDay}
+          historicalItems={historicalItems}
+          historicalEdition={historicalEdition}
+          historicalLabel={historicalLabel}
+          lastDay={lastDay}
+          mobileActiveDay={activeSection === 'last' ? 'last' : 'first'}
+          startDate={startDate}
+        />
+      </div>
+    </div>
+  );
+};

--- a/components/Frontpage/HomepageCompanySections.unit.test.js
+++ b/components/Frontpage/HomepageCompanySections.unit.test.js
@@ -1,0 +1,183 @@
+/** @jest-environment jsdom */
+
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import { HomepageCompanySections } from './HomepageCompanySections';
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+const company = {
+  id: 'company',
+  logo: null,
+  name: 'Bedrift',
+  url: null,
+};
+
+const partner = {
+  id: 'partner',
+  logo: null,
+  name: 'Partner',
+  url: null,
+};
+
+const historicalItems = [
+  {
+    id: 'historical-company',
+    logo: null,
+    name: 'Tidligere bedrift',
+  },
+];
+
+describe('HomepageCompanySections', () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  const renderSections = ({
+    firstDay = [company],
+    lastDay = [company],
+    partners = [partner],
+  } = {}) => {
+    act(() => {
+      root.render(
+        <HomepageCompanySections
+          edition={2026}
+          endDate="2026-09-15"
+          firstDay={firstDay}
+          historicalEdition={2025}
+          historicalItems={historicalItems}
+          historicalLabel="Tidligere bedrifter"
+          lastDay={lastDay}
+          mainPartner={null}
+          partners={partners}
+          startDate="2026-09-14"
+        />
+      );
+    });
+  };
+
+  it('keeps all company sections rendered while switching the mobile view', () => {
+    renderSections();
+
+    const buttons = [
+      ...container.querySelectorAll('.segmented-control button'),
+    ];
+    const partnerPanel = container.querySelector(
+      '[data-company-mobile-panel="partners"]'
+    );
+    const directoryPanel = container.querySelector(
+      '[data-company-mobile-panel="directory"]'
+    );
+    const days = container.querySelectorAll('[data-company-day]');
+
+    expect(buttons.map((button) => button.textContent)).toEqual([
+      'Samarbeidspartnere',
+      'Mandag',
+      'Tirsdag',
+    ]);
+    expect(partnerPanel.dataset.mobileActive).toBe('true');
+    expect(directoryPanel.dataset.mobileActive).toBe('false');
+    expect(days).toHaveLength(2);
+
+    act(() => buttons[1].click());
+    expect(partnerPanel.dataset.mobileActive).toBe('false');
+    expect(directoryPanel.dataset.mobileActive).toBe('true');
+    expect(days[0].dataset.mobileActive).toBe('true');
+    expect(days[1].dataset.mobileActive).toBe('false');
+
+    act(() => buttons[2].click());
+    expect(days[0].dataset.mobileActive).toBe('false');
+    expect(days[1].dataset.mobileActive).toBe('true');
+    expect(container.textContent).toContain('Partner');
+    expect(container.querySelectorAll('[data-company-id]')).toHaveLength(2);
+  });
+
+  it('does not add a selector to the historical fallback', () => {
+    renderSections({ firstDay: null, lastDay: null });
+
+    expect(container.querySelector('.segmented-control')).toBeNull();
+    expect(
+      container.querySelector('[data-company-mobile-panel="directory"]').dataset
+        .mobileActive
+    ).toBe('true');
+    expect(container.textContent).toContain('Tidligere bedrifter');
+  });
+
+  it('starts with the available day when no partner or first day is published', () => {
+    renderSections({ firstDay: null, lastDay: [company], partners: [] });
+
+    expect(container.firstElementChild.dataset.companyMobileSection).toBe(
+      'last'
+    );
+    expect(
+      container.querySelector('[data-company-day="last"]').dataset.mobileActive
+    ).toBe('true');
+  });
+
+  it('keeps a visible selection when live data removes the partner panel', () => {
+    renderSections();
+    expect(container.firstElementChild.dataset.companyMobileSection).toBe(
+      'partners'
+    );
+
+    renderSections({ firstDay: null, lastDay: [company], partners: [] });
+
+    expect(container.firstElementChild.dataset.companyMobileSection).toBe(
+      'last'
+    );
+    expect(
+      container.querySelector('[data-company-mobile-panel="directory"]').dataset
+        .mobileActive
+    ).toBe('true');
+    expect(
+      container.querySelector('[data-company-day="last"]').dataset.mobileActive
+    ).toBe('true');
+    expect(
+      [...container.querySelectorAll('.segmented-control button')].some(
+        (button) => button.getAttribute('aria-pressed') === 'true'
+      )
+    ).toBe(true);
+  });
+
+  it('moves from a removed selected day to the remaining published day', () => {
+    renderSections({ partners: [] });
+    let buttons = [...container.querySelectorAll('.segmented-control button')];
+
+    act(() => buttons[1].click());
+    expect(container.firstElementChild.dataset.companyMobileSection).toBe(
+      'last'
+    );
+
+    renderSections({ firstDay: [company], lastDay: null, partners: [] });
+    expect(container.firstElementChild.dataset.companyMobileSection).toBe(
+      'first'
+    );
+    expect(
+      container.querySelector('[data-company-day="first"]').dataset.mobileActive
+    ).toBe('true');
+
+    renderSections({ firstDay: [company], lastDay: [company], partners: [] });
+    buttons = [...container.querySelectorAll('.segmented-control button')];
+    act(() => buttons[0].click());
+    renderSections({ firstDay: null, lastDay: [company], partners: [] });
+
+    expect(container.firstElementChild.dataset.companyMobileSection).toBe(
+      'last'
+    );
+    expect(
+      container.querySelector('[data-company-day="last"]').dataset.mobileActive
+    ).toBe('true');
+  });
+});

--- a/components/Frontpage/VisitPlanner.tsx
+++ b/components/Frontpage/VisitPlanner.tsx
@@ -47,7 +47,7 @@ export const VisitPlanner = ({
     {
       key: 'jobs',
       title: 'Jobb',
-      description: 'Se jobb- og sommerjobbmuligheter.',
+      description: 'Se ledige jobber og sommerjobber.',
       href: '/jobb',
     },
     {
@@ -69,9 +69,11 @@ export const VisitPlanner = ({
             <li className={`visit-planner__item--${route.key}`} key={route.key}>
               <Link href={route.href}>
                 <span aria-hidden="true" className="visit-planner__marker" />
-                <h3>{route.title}</h3>
-                <p>{route.description}</p>
-                {route.state && <small>{route.state}</small>}
+                <span className="visit-planner__copy">
+                  <h3>{route.title}</h3>
+                  <p>{route.description}</p>
+                  {route.state && <small>{route.state}</small>}
+                </span>
               </Link>
             </li>
           ))}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,10 +3,9 @@ import Head from 'next/head';
 import { graphql } from 'react-relay';
 import { pages_index_QueryResponse } from '../__generated__/pages_index_Query.graphql';
 import { ContentStatePanel, SiteSection } from '../components/DesignSystem';
-import { CompanyExposure } from '../components/Frontpage/CompanyExposure';
 import { EmployerInvitation } from '../components/Frontpage/EmployerInvitation';
 import { HomeBriefing } from '../components/Frontpage/HomeBriefing';
-import { PartnerShowcase } from '../components/Frontpage/PartnerTiers';
+import { HomepageCompanySections } from '../components/Frontpage/HomepageCompanySections';
 import WelcomeScreen from '../components/Frontpage/WelcomeScreen';
 import { editionConfig } from '../config/edition';
 import { withDataAndLayout, WithDataAndLayoutProps } from '../lib/withData';
@@ -111,12 +110,7 @@ const Index = ({
         venue={optionalEventConfiguration.venue || DEFAULT_EVENT_VENUE}
       />
 
-      <PartnerShowcase
-        mainPartner={props.currentMetaData.mainCollaborator}
-        partners={props.currentMetaData.collaborators || []}
-      />
-
-      <CompanyExposure
+      <HomepageCompanySections
         edition={currentEdition}
         endDate={props.currentMetaData.endDate}
         firstDay={props.currentMetaData.companiesFirstDay}
@@ -124,6 +118,8 @@ const Index = ({
         historicalEdition={companyMarquee.edition}
         historicalLabel={companyMarquee.label}
         lastDay={props.currentMetaData.companiesLastDay}
+        mainPartner={props.currentMetaData.mainCollaborator}
+        partners={props.currentMetaData.collaborators || []}
         startDate={props.currentMetaData.startDate}
       />
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -99,41 +99,44 @@ const Index = ({
           type="application/ld+json"
         />
       </Head>
-      <WelcomeScreen
-        currentMetaData={props.currentMetaData}
-        eventStartTime={
-          optionalEventConfiguration.eventStartTime || DEFAULT_EVENT_START_TIME
-        }
-        phase={phase}
-        programState={programState}
-        standState={standState}
-        venue={optionalEventConfiguration.venue || DEFAULT_EVENT_VENUE}
-      />
+      <div className="homepage">
+        <WelcomeScreen
+          currentMetaData={props.currentMetaData}
+          eventStartTime={
+            optionalEventConfiguration.eventStartTime ||
+            DEFAULT_EVENT_START_TIME
+          }
+          phase={phase}
+          programState={programState}
+          standState={standState}
+          venue={optionalEventConfiguration.venue || DEFAULT_EVENT_VENUE}
+        />
 
-      <HomepageCompanySections
-        edition={currentEdition}
-        endDate={props.currentMetaData.endDate}
-        firstDay={props.currentMetaData.companiesFirstDay}
-        historicalItems={companyMarquee.items}
-        historicalEdition={companyMarquee.edition}
-        historicalLabel={companyMarquee.label}
-        lastDay={props.currentMetaData.companiesLastDay}
-        mainPartner={props.currentMetaData.mainCollaborator}
-        partners={props.currentMetaData.collaborators || []}
-        startDate={props.currentMetaData.startDate}
-      />
+        <HomepageCompanySections
+          edition={currentEdition}
+          endDate={props.currentMetaData.endDate}
+          firstDay={props.currentMetaData.companiesFirstDay}
+          historicalItems={companyMarquee.items}
+          historicalEdition={companyMarquee.edition}
+          historicalLabel={companyMarquee.label}
+          lastDay={props.currentMetaData.companiesLastDay}
+          mainPartner={props.currentMetaData.mainCollaborator}
+          partners={props.currentMetaData.collaborators || []}
+          startDate={props.currentMetaData.startDate}
+        />
 
-      <HomeBriefing
-        edition={currentEdition}
-        events={props.events || []}
-        phase={phase}
-        programState={programState}
-        referenceTime={referenceTime}
-        standMap={currentStandMap || undefined}
-        standState={standState}
-      />
+        <HomeBriefing
+          edition={currentEdition}
+          events={props.events || []}
+          phase={phase}
+          programState={programState}
+          referenceTime={referenceTime}
+          standMap={currentStandMap || undefined}
+          standState={standState}
+        />
 
-      <EmployerInvitation edition={currentEdition} />
+        <EmployerInvitation edition={currentEdition} />
+      </div>
     </>
   );
 };

--- a/styles/site.css
+++ b/styles/site.css
@@ -4924,3 +4924,105 @@ a.current-company-directory__logo:active {
     display: none;
   }
 }
+
+@media (min-width: 1441px) {
+  .homepage {
+    --site-width: calc(100vw - clamp(8rem, 8vw, 10rem));
+  }
+
+  .homepage .event-hero__intro {
+    width: 92vw;
+  }
+
+  .homepage .event-hero__intro-title {
+    font-size: clamp(12rem, 13vw, 16rem);
+  }
+
+  .homepage .event-hero__arrival {
+    width: min(calc(100% - 4rem), 92vw);
+  }
+
+  .homepage .event-hero__arrival-copy {
+    font-size: clamp(0.95rem, 0.8vw, 1.2rem);
+  }
+
+  .homepage .event-hero__arrival-copy span {
+    font-size: clamp(1.1rem, 0.9vw, 1.35rem);
+  }
+
+  .homepage .event-hero__static-purpose {
+    max-width: 64rem;
+  }
+
+  .homepage .event-hero__static-purpose p {
+    font-size: clamp(4.5rem, 5vw, 7.5rem);
+  }
+
+  .homepage .event-hero__static-purpose span {
+    max-width: 48rem;
+    font-size: clamp(1.05rem, 1vw, 1.35rem);
+  }
+
+  .homepage .event-hero__logo-anchor {
+    width: clamp(7.25rem, 8vw, 10rem);
+  }
+
+  .homepage .event-hero__assembled-logo {
+    width: clamp(31rem, 34vw, 50rem);
+  }
+
+  .homepage .event-hero__content {
+    width: min(52vw, 72rem);
+  }
+
+  .homepage .event-hero__coordinates {
+    font-size: clamp(0.92rem, 0.75vw, 1.1rem);
+  }
+
+  .homepage .event-hero__resolved-title {
+    font-size: clamp(5.6rem, 5.6vw, 9rem);
+  }
+
+  .homepage .event-hero__description {
+    max-width: 48rem;
+    font-size: clamp(1.18rem, 1vw, 1.5rem);
+  }
+
+  .homepage .event-countdown {
+    width: min(100%, clamp(36rem, 30vw, 48rem));
+  }
+
+  .homepage .event-countdown__unit dd {
+    font-size: clamp(2.75rem, 2.25vw, 3.5rem);
+  }
+
+  .homepage .current-company-directory__heading h2,
+  .homepage .partner-showcase__primary-copy h2,
+  .homepage .visit-planner__heading h2,
+  .homepage .current-event-preview__heading h2,
+  .homepage .documentary-band__heading h2,
+  .homepage .employer-invitation h2 {
+    font-size: clamp(4rem, 3.8vw, 5.75rem);
+  }
+
+  .homepage .visit-planner h3 {
+    font-size: clamp(2rem, 1.8vw, 2.75rem);
+  }
+
+  .homepage .visit-planner p,
+  .homepage .current-event-preview__heading > p:last-child,
+  .homepage .documentary-band__heading > p,
+  .homepage .employer-invitation p {
+    font-size: clamp(1rem, 0.85vw, 1.3rem);
+  }
+}
+
+@media (min-width: 1920px) {
+  .homepage .current-company-directory__grid {
+    grid-template-columns: repeat(8, minmax(0, 1fr));
+  }
+
+  .homepage .current-company-directory__grid li {
+    min-height: clamp(8.5rem, 8vw, 11rem);
+  }
+}

--- a/styles/site.css
+++ b/styles/site.css
@@ -3687,6 +3687,10 @@ html[data-hero-mode='static'] .site-header--cinematic .site-navigation li a {
   background: #f8fbfc;
 }
 
+.homepage-company-sections__switcher {
+  display: none;
+}
+
 .current-company-directory__heading {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
@@ -4086,10 +4090,15 @@ a.current-company-directory__logo:active {
 .visit-planner__marker {
   display: block;
   width: 1.15rem;
-  margin-bottom: auto;
+  margin-bottom: var(--space-7);
   aspect-ratio: 1;
   background: var(--route-color);
   transition: transform 180ms ease;
+}
+
+.visit-planner__copy {
+  display: block;
+  min-width: 0;
 }
 
 .visit-planner a:hover .visit-planner__marker {
@@ -4113,7 +4122,7 @@ a.current-company-directory__logo:active {
 }
 
 .visit-planner h3 {
-  margin: var(--space-7) 0 var(--space-3);
+  margin: 0 0 var(--space-3);
   font-size: clamp(1.45rem, 2.2vw, 2rem);
   letter-spacing: -0.025em;
 }
@@ -4121,6 +4130,7 @@ a.current-company-directory__logo:active {
 .visit-planner p {
   margin: 0;
   color: var(--color-ink-muted);
+  overflow-wrap: break-word;
 }
 
 .visit-planner small {
@@ -4129,6 +4139,13 @@ a.current-company-directory__logo:active {
   color: var(--color-ink-muted);
   font-size: 0.78rem;
   font-weight: 600;
+  overflow-wrap: break-word;
+}
+
+@media (min-width: 1025px) {
+  .visit-planner p {
+    min-height: 3.2em;
+  }
 }
 
 .current-event-preview > .site-container {
@@ -4462,6 +4479,10 @@ a.current-company-directory__logo:active {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
+  .visit-planner p {
+    min-height: 3.2em;
+  }
+
   .visit-planner li:nth-child(even) {
     border-left: 1px solid var(--color-border);
   }
@@ -4507,6 +4528,60 @@ a.current-company-directory__logo:active {
 
   .site-header--cinematic .site-navigation__link {
     --navigation-underline: var(--navigation-route-underline);
+  }
+
+  .homepage-company-sections__switcher {
+    position: sticky;
+    z-index: 4;
+    top: 4.5rem;
+    display: block;
+    padding-block: var(--space-3);
+    border-bottom: 1px solid var(--color-border);
+    background: rgba(255, 255, 255, 0.96);
+    backdrop-filter: blur(14px);
+  }
+
+  .homepage-company-sections__switcher .segmented-control {
+    display: grid;
+    width: 100%;
+    padding: 0;
+    grid-auto-columns: minmax(0, 1fr);
+    grid-auto-flow: column;
+    gap: 0;
+    overflow: hidden;
+  }
+
+  .homepage-company-sections__switcher .segmented-control__item {
+    min-width: 0;
+    min-height: 3.25rem;
+    padding-inline: var(--space-2);
+    border-radius: 0;
+    font-size: clamp(0.72rem, 3.2vw, 0.9rem);
+    hyphens: auto;
+    line-height: 1.15;
+    overflow-wrap: anywhere;
+    white-space: normal;
+  }
+
+  .homepage-company-sections__switcher .segmented-control__item:first-child {
+    border-radius: calc(var(--radius-control) - 1px) 0 0
+      calc(var(--radius-control) - 1px);
+  }
+
+  .homepage-company-sections__switcher .segmented-control__item:last-child {
+    border-radius: 0 calc(var(--radius-control) - 1px)
+      calc(var(--radius-control) - 1px) 0;
+  }
+
+  .homepage-company-sections__switcher .segmented-control__item:focus-visible {
+    outline-offset: -3px;
+  }
+
+  .homepage-company-sections
+    [data-company-mobile-panel][data-mobile-active='false'],
+  .homepage-company-sections
+    .current-company-directory__day[data-mobile-active='false'] {
+    display: none;
   }
 
   .current-company-directory__heading {
@@ -4605,7 +4680,11 @@ a.current-company-directory__logo:active {
   }
 
   .visit-planner h3 {
-    margin-top: var(--space-5);
+    margin-top: 0;
+  }
+
+  .visit-planner__marker {
+    margin-bottom: var(--space-5);
   }
 
   .current-event-preview__planning {
@@ -4710,6 +4789,10 @@ a.current-company-directory__logo:active {
     display: block;
   }
 
+  .visit-planner p {
+    min-height: 4.8em;
+  }
+
   .current-company-directory__day-heading p {
     margin-top: var(--space-2);
   }
@@ -4768,6 +4851,10 @@ a.current-company-directory__logo:active {
 
   .event-countdown__values {
     gap: 0.2rem;
+  }
+
+  .visit-planner p {
+    min-height: 0;
   }
 
   .event-countdown__unit {


### PR DESCRIPTION
## Summary

- Add a shared mobile switcher for partners, Monday companies, and Tuesday companies while keeping every section visible on desktop.
- Preserve server-rendered company content and reconcile the active mobile selection when publication data changes.
- Align the visit-planner cards across desktop and mobile, contain long copy, and keep route-specific styling consistent.
- Add focused unit and browser regression coverage for publication states, keyboard operation, narrow widths, and card alignment.

## Before: 

<img width="377" height="758" alt="image" src="https://github.com/user-attachments/assets/b48c6794-9cdf-427d-8295-efea702322ca" />
<img width="401" height="541" alt="image" src="https://github.com/user-attachments/assets/982c2491-3d79-4505-8c6f-3c05ca5cef6e" />



## After:
<img width="387" height="554" alt="image" src="https://github.com/user-attachments/assets/03e376a6-dd67-4dec-b00c-b221ba440ed1" />
<img width="434" height="533" alt="image" src="https://github.com/user-attachments/assets/6924ddb5-27d8-4618-bafd-d7b93373bb5e" />

## Why

The redesigned homepage gave company sections good desktop exposure, but the mobile presentation required excessive scrolling.
The visit-planner cards also had inconsistent text alignment and could overflow at narrow widths.

This change makes the mobile company journey compact without reducing desktop exposure, and gives the planner cards a consistent visual rhythm at every supported breakpoint.

## Validation

- `yarn lint`
- `yarn test:unit` - 24 suites and 96 tests passed
- `yarn build`
- Focused Puppeteer E2E coverage at 320, 375, 390, and 1440 pixels
- Visual checks at desktop and narrow mobile widths

No backend schema or API changes are required.
