### PR TITLE
Fix localhost not working on Windows

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -69,6 +69,7 @@ module.exports = withSourceMaps({
     if (!isServer) {
       config.resolve.alias['@sentry/node'] = '@sentry/browser'
     }
+    config.resolve.preferRelative = true;
     if (SENTRY_ORG && SENTRY_PROJECT) {
       config.plugins.push(
       new SentryWebpackPlugin({


### PR DESCRIPTION
Fix Windows dev/build failure: enable `preferRelative` so paths resolve correctly.

To test, run the site locally on windows.
